### PR TITLE
Custom parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Cova is based on the idea that Arguments will fall into one of three categories:
   - [x] Mandate Values be filled.
   - [x] Custom prefixes for Options.
   - [x] Custom separator between Options and Values. (Currently accepts ' ' or '=').
-  - [ ] Choose behavior for having the same option given multiple times.
+  - [x] Choose behavior for having the same option given multiple times.
   - [x] Choose whether or not to skip the first Argument (the executable's name).
 - [ ] Setup Features:
   - [ ] Set up the build.zig and build.zig.zon for install and use in other codebases.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Cova is based on the idea that Arguments will fall into one of three categories:
 - [ ] Advanced Parsing:
   - [x] Handle '=' instead of ' ' between an Option and its Value.
   - [x] Handle the same Option given multiple times. (Currently takes last value.)
-  - [ ] Handle no space ' ' between a Short Option and its Value.
+  - [x] Handle no space ' ' between a Short Option and its Value.
   - [ ] Tab Completion (long-term goal).
 - [ ] Parsing Customization:
-  - [ ] Mandate Values be filled.
+  - [x] Mandate Values be filled.
   - [x] Custom prefixes for Options.
-  - [ ] Custom separator between Options and Values. (Currently accepts ' ' or '=').
+  - [x] Custom separator between Options and Values. (Currently accepts ' ' or '=').
   - [ ] Choose behavior for having the same option given multiple times.
-  - [ ] Choose whether or not to skip the first Argument (the executable's name).
+  - [x] Choose whether or not to skip the first Argument (the executable's name).
 - [ ] Setup Features:
   - [ ] Set up the build.zig and build.zig.zon for install and use in other codebases.
     - [ ] Proper library tests. 

--- a/covademo.zig
+++ b/covademo.zig
@@ -72,7 +72,7 @@ const setup_cmd: CustomCommand = .{
                     .set_behavior = .Multi,
                     .max_args = 4,
                 }),
-                .description = "A string option.",
+                .description = "A string option. (Can be given up to 4 times.)",
             },
             &CustomCommand.CustomOption{
                 .name = "intOpt",
@@ -85,7 +85,7 @@ const setup_cmd: CustomCommand = .{
                     .set_behavior = .Multi,
                     .max_args = 10,
                 }),
-                .description = "An integer option.",
+                .description = "An integer option. (Can be given up to 10 times.)",
             },
             &CustomCommand.CustomOption{
                 .name = "toggle",

--- a/covademo.zig
+++ b/covademo.zig
@@ -134,7 +134,7 @@ pub fn main() !void {
     defer main_cmd.deinit(alloc);
 
     const args = try proc.argsWithAllocator(alloc);
-    try cova.parseArgs(&args, CustomCommand, main_cmd, stdout, .{ .vals_mandatory = false });
+    try cova.parseArgs(&args, CustomCommand, main_cmd, stdout, .{ .vals_mandatory = false, .allow_opt_val_no_space = true });
     try stdout.print("\n", .{});
     try displayCmdInfo(main_cmd, alloc);
 

--- a/docs/src/cova/Command.zig.html
+++ b/docs/src/cova/Command.zig.html
@@ -132,7 +132,7 @@
 <span class="line" id="L19"><span class="tok-kw">const</span> StringHashMap = std.StringHashMap;</span>
 <span class="line" id="L20"></span>
 <span class="line" id="L21"><span class="tok-kw">const</span> Option = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;Option.zig&quot;</span>);</span>
-<span class="line" id="L22"><span class="tok-kw">const</span> Val = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;Value.zig&quot;</span>);</span>
+<span class="line" id="L22"><span class="tok-kw">const</span> Value = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;Value.zig&quot;</span>);</span>
 <span class="line" id="L23"></span>
 <span class="line" id="L24"></span>
 <span class="line" id="L25"><span class="tok-comment">/// Config for custom Command types. </span></span>
@@ -189,7 +189,7 @@
 <span class="line" id="L76">        <span class="tok-comment">/// The list of Options this Command can take.</span></span>
 <span class="line" id="L77">        opts: ?[]*<span class="tok-kw">const</span> CustomOption = <span class="tok-null">null</span>,</span>
 <span class="line" id="L78">        <span class="tok-comment">/// The list of Values this Command can take.</span></span>
-<span class="line" id="L79">        vals: ?[]*<span class="tok-kw">const</span> Val.Generic = <span class="tok-null">null</span>,</span>
+<span class="line" id="L79">        vals: ?[]*<span class="tok-kw">const</span> Value.Generic = <span class="tok-null">null</span>,</span>
 <span class="line" id="L80"></span>
 <span class="line" id="L81">        <span class="tok-comment">/// The Name of this Command for user identification and Usage/Help messages.</span></span>
 <span class="line" id="L82">        name: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>,</span>
@@ -212,9 +212,9 @@
 <span class="line" id="L99">        }</span>
 <span class="line" id="L100"></span>
 <span class="line" id="L101">        <span class="tok-comment">/// Gets a StringHashMap of this Command's Values.</span></span>
-<span class="line" id="L102">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">getVals</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), alloc: mem.Allocator) !StringHashMap(*<span class="tok-kw">const</span> Val) {</span>
+<span class="line" id="L102">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">getVals</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), alloc: mem.Allocator) !StringHashMap(*<span class="tok-kw">const</span> Value) {</span>
 <span class="line" id="L103">            <span class="tok-kw">if</span> (self.vals == <span class="tok-null">null</span>) <span class="tok-kw">return</span> <span class="tok-kw">error</span>.NoValuesInCommand;</span>
-<span class="line" id="L104">            <span class="tok-kw">var</span> map = StringHashMap(*<span class="tok-kw">const</span> Val).init(alloc);</span>
+<span class="line" id="L104">            <span class="tok-kw">var</span> map = StringHashMap(*<span class="tok-kw">const</span> Value).init(alloc);</span>
 <span class="line" id="L105">            <span class="tok-kw">for</span> (self.vals.?) |val| { <span class="tok-kw">try</span> map.put(val.name, val); }</span>
 <span class="line" id="L106">            <span class="tok-kw">return</span> map;</span>
 <span class="line" id="L107">        }</span>
@@ -227,11 +227,11 @@
 <span class="line" id="L114"></span>
 <span class="line" id="L115">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">\\HELP:</span></span>
 
-<span class="line" id="L116">                             <span class="tok-str">\\    Command: {s}</span></span>
+<span class="line" id="L116">                             <span class="tok-str">\\    COMMAND: {s}</span></span>
 
 <span class="line" id="L117">                             <span class="tok-str">\\</span></span>
 
-<span class="line" id="L118">                             <span class="tok-str">\\    Description: {s}</span></span>
+<span class="line" id="L118">                             <span class="tok-str">\\    DESCRIPTION: {s}</span></span>
 
 <span class="line" id="L119">                             <span class="tok-str">\\</span></span>
 
@@ -240,7 +240,7 @@
 <span class="line" id="L121">                             , .{ self.name, self.description });</span>
 <span class="line" id="L122">            </span>
 <span class="line" id="L123">            <span class="tok-kw">if</span> (self.sub_cmds != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L124">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;    Sub Commands:\n&quot;</span>, .{});</span>
+<span class="line" id="L124">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;    SUB COMMANDS:\n&quot;</span>, .{});</span>
 <span class="line" id="L125">                <span class="tok-kw">for</span> (self.sub_cmds.?) |cmd| {</span>
 <span class="line" id="L126">                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;        &quot;</span>, .{});</span>
 <span class="line" id="L127">                    <span class="tok-kw">try</span> writer.print(subcmds_help_fmt, .{cmd.name, cmd.description});</span>
@@ -250,7 +250,7 @@
 <span class="line" id="L131">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n&quot;</span>, .{});</span>
 <span class="line" id="L132"></span>
 <span class="line" id="L133">            <span class="tok-kw">if</span> (self.opts != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L134">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;    Options:\n&quot;</span>, .{});</span>
+<span class="line" id="L134">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;    OPTIONS:\n&quot;</span>, .{});</span>
 <span class="line" id="L135">                <span class="tok-kw">for</span> (self.opts.?) |opt| {</span>
 <span class="line" id="L136">                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;        &quot;</span>, .{});</span>
 <span class="line" id="L137">                    <span class="tok-kw">try</span> opt.help(writer);</span>
@@ -260,7 +260,7 @@
 <span class="line" id="L141">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n&quot;</span>, .{});</span>
 <span class="line" id="L142"></span>
 <span class="line" id="L143">            <span class="tok-kw">if</span> (self.vals != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L144">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;    Values:\n&quot;</span>, .{});</span>
+<span class="line" id="L144">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;    VALUES:\n&quot;</span>, .{});</span>
 <span class="line" id="L145">                <span class="tok-kw">for</span> (self.vals.?) |val| {</span>
 <span class="line" id="L146">                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;        &quot;</span>, .{});</span>
 <span class="line" id="L147">                    <span class="tok-kw">try</span> writer.print(vals_help_fmt, .{ val.name(), val.valType(), val.description() });</span>
@@ -299,227 +299,259 @@
 <span class="line" id="L179">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
 <span class="line" id="L180">        }</span>
 <span class="line" id="L181"></span>
-<span class="line" id="L182">        <span class="tok-comment">/// Find the Index of a Slice (Why is this not in std.mem?!?!?)</span></span>
-<span class="line" id="L183">        <span class="tok-kw">fn</span> <span class="tok-fn">indexOfEql</span>(<span class="tok-kw">comptime</span> T: <span class="tok-type">type</span>, haystack: []<span class="tok-kw">const</span> T, needle: T) ?<span class="tok-type">usize</span> {</span>
-<span class="line" id="L184">            <span class="tok-kw">switch</span> (<span class="tok-builtin">@typeInfo</span>(T)) {</span>
-<span class="line" id="L185">                .Pointer =&gt; |ptr| {</span>
-<span class="line" id="L186">                    <span class="tok-kw">for</span> (haystack, <span class="tok-number">0</span>..) |hay, idx| <span class="tok-kw">if</span> (mem.eql(ptr.child, hay, needle)) <span class="tok-kw">return</span> idx;</span>
-<span class="line" id="L187">                    <span class="tok-kw">return</span> <span class="tok-null">null</span>;</span>
-<span class="line" id="L188">                },</span>
-<span class="line" id="L189">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; <span class="tok-kw">return</span> mem.indexOfScalar(T, haystack, needle),</span>
-<span class="line" id="L190">            }</span>
-<span class="line" id="L191">        }</span>
-<span class="line" id="L192"></span>
-<span class="line" id="L193">        <span class="tok-comment">/// Validate this Command during Comptime for distinct Sub Commands, Options, and Values. </span></span>
-<span class="line" id="L194">        <span class="tok-comment">/// This will also Validate Sub Commands recursively.</span></span>
-<span class="line" id="L195">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">validate</span>(<span class="tok-kw">comptime</span> self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) <span class="tok-type">void</span> {</span>
-<span class="line" id="L196">            <span class="tok-kw">comptime</span> {</span>
-<span class="line" id="L197">                <span class="tok-builtin">@setEvalBranchQuota</span>(<span class="tok-number">100_000</span>);</span>
-<span class="line" id="L198">                <span class="tok-comment">// Check for distinct Sub Commands and Validate them.</span>
-</span>
-<span class="line" id="L199">                <span class="tok-kw">if</span> (self.sub_cmds != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L200">                    <span class="tok-kw">const</span> cmds = self.sub_cmds.?;</span>
-<span class="line" id="L201">                    <span class="tok-kw">var</span> distinct_cmd: [<span class="tok-number">100</span>][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** <span class="tok-number">100</span>;</span>
-<span class="line" id="L202">                    <span class="tok-kw">for</span> (cmds, <span class="tok-number">0</span>..) |cmd, idx| {</span>
-<span class="line" id="L203">                        <span class="tok-kw">if</span> (indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_cmd[<span class="tok-number">0</span>..idx], cmd.name) != <span class="tok-null">null</span>) </span>
-<span class="line" id="L204">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Sub Command '&quot;</span> ++ cmd.name ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
-<span class="line" id="L205">                        <span class="tok-comment">//cmd.validate();</span>
-</span>
-<span class="line" id="L206">                        distinct_cmd[idx] = cmd.name;</span>
-<span class="line" id="L207">                    }</span>
+<span class="line" id="L182">        <span class="tok-comment">/// Check if a Flag has been set on this Command as a Command, an Option, or a Value.</span></span>
+<span class="line" id="L183">        <span class="tok-comment">/// This is particularly useful for checking if Help or Usage has been called.</span></span>
+<span class="line" id="L184">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">checkFlag</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), toggle_name: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) <span class="tok-type">bool</span> {</span>
+<span class="line" id="L185">            <span class="tok-kw">return</span> (</span>
+<span class="line" id="L186">                (self.sub_cmd != <span class="tok-null">null</span> <span class="tok-kw">and</span> mem.eql(<span class="tok-type">u8</span>, self.sub_cmd.?.name, toggle_name)) <span class="tok-kw">or</span></span>
+<span class="line" id="L187">                checkOpt: {</span>
+<span class="line" id="L188">                    <span class="tok-kw">if</span> (self.opts != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L189">                        <span class="tok-kw">for</span> (self.opts.?) |opt| {</span>
+<span class="line" id="L190">                            <span class="tok-kw">if</span> (mem.eql(<span class="tok-type">u8</span>, opt.name, toggle_name) <span class="tok-kw">and</span> </span>
+<span class="line" id="L191">                                mem.eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>) <span class="tok-kw">and</span> </span>
+<span class="line" id="L192">                                opt.val.<span class="tok-type">bool</span>.get() <span class="tok-kw">catch</span> <span class="tok-null">false</span>)</span>
+<span class="line" id="L193">                                    <span class="tok-kw">break</span> :checkOpt <span class="tok-null">true</span>;</span>
+<span class="line" id="L194">                        }</span>
+<span class="line" id="L195">                    }</span>
+<span class="line" id="L196">                    <span class="tok-kw">break</span> :checkOpt <span class="tok-null">false</span>;</span>
+<span class="line" id="L197">                } <span class="tok-kw">or</span></span>
+<span class="line" id="L198">                checkVal: {</span>
+<span class="line" id="L199">                    <span class="tok-kw">if</span> (self.vals != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L200">                        <span class="tok-kw">for</span> (self.vals.?) |val| {</span>
+<span class="line" id="L201">                            <span class="tok-kw">if</span> (mem.eql(<span class="tok-type">u8</span>, val.name(), toggle_name) <span class="tok-kw">and</span></span>
+<span class="line" id="L202">                                mem.eql(<span class="tok-type">u8</span>, val.valType(), <span class="tok-str">&quot;bool&quot;</span>) <span class="tok-kw">and</span></span>
+<span class="line" id="L203">                                val.<span class="tok-type">bool</span>.get() <span class="tok-kw">catch</span> <span class="tok-null">false</span>)</span>
+<span class="line" id="L204">                                    <span class="tok-kw">break</span> :checkVal <span class="tok-null">true</span>;</span>
+<span class="line" id="L205">                        }</span>
+<span class="line" id="L206">                    }</span>
+<span class="line" id="L207">                    <span class="tok-kw">break</span> :checkVal <span class="tok-null">false</span>;</span>
 <span class="line" id="L208">                }</span>
-<span class="line" id="L209"></span>
-<span class="line" id="L210">                <span class="tok-comment">// Check for distinct Options.</span>
+<span class="line" id="L209">            );</span>
+<span class="line" id="L210">        }</span>
+<span class="line" id="L211"></span>
+<span class="line" id="L212">        <span class="tok-comment">/// Find the Index of a Slice (Why is this not in std.mem?!?!? Did I miss it?)</span></span>
+<span class="line" id="L213">        <span class="tok-kw">fn</span> <span class="tok-fn">indexOfEql</span>(<span class="tok-kw">comptime</span> T: <span class="tok-type">type</span>, haystack: []<span class="tok-kw">const</span> T, needle: T) ?<span class="tok-type">usize</span> {</span>
+<span class="line" id="L214">            <span class="tok-kw">switch</span> (<span class="tok-builtin">@typeInfo</span>(T)) {</span>
+<span class="line" id="L215">                .Pointer =&gt; |ptr| {</span>
+<span class="line" id="L216">                    <span class="tok-kw">for</span> (haystack, <span class="tok-number">0</span>..) |hay, idx| <span class="tok-kw">if</span> (mem.eql(ptr.child, hay, needle)) <span class="tok-kw">return</span> idx;</span>
+<span class="line" id="L217">                    <span class="tok-kw">return</span> <span class="tok-null">null</span>;</span>
+<span class="line" id="L218">                },</span>
+<span class="line" id="L219">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; <span class="tok-kw">return</span> mem.indexOfScalar(T, haystack, needle),</span>
+<span class="line" id="L220">            }</span>
+<span class="line" id="L221">        }</span>
+<span class="line" id="L222"></span>
+<span class="line" id="L223">        <span class="tok-comment">/// Validate this Command during Comptime for distinct Sub Commands, Options, and Values. </span></span>
+<span class="line" id="L224">        <span class="tok-comment">/// This will also Validate Sub Commands recursively.</span></span>
+<span class="line" id="L225">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">validate</span>(<span class="tok-kw">comptime</span> self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) <span class="tok-type">void</span> {</span>
+<span class="line" id="L226">            <span class="tok-kw">comptime</span> {</span>
+<span class="line" id="L227">                <span class="tok-builtin">@setEvalBranchQuota</span>(<span class="tok-number">100_000</span>);</span>
+<span class="line" id="L228">                <span class="tok-comment">// This is an arbitrary (but hopefully higher than needed) limit to the number of Arguments than be Validated each of Commands, Options, and Values.</span>
 </span>
-<span class="line" id="L211">                <span class="tok-kw">if</span> (self.opts != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L212">                    <span class="tok-kw">const</span> opts = self.opts.?;</span>
-<span class="line" id="L213">                    <span class="tok-kw">var</span> distinct_name: [<span class="tok-number">100</span>][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** <span class="tok-number">100</span>;</span>
-<span class="line" id="L214">                    <span class="tok-kw">var</span> distinct_short: [<span class="tok-number">100</span>]<span class="tok-type">u8</span> = .{ <span class="tok-str">' '</span> } ** <span class="tok-number">100</span>;</span>
-<span class="line" id="L215">                    <span class="tok-kw">var</span> distinct_long: [<span class="tok-number">100</span>][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** <span class="tok-number">100</span>;</span>
-<span class="line" id="L216">                    <span class="tok-kw">for</span> (opts, <span class="tok-number">0</span>..) |opt, idx| {</span>
-<span class="line" id="L217">                        <span class="tok-kw">if</span> (indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_name[<span class="tok-number">0</span>..], opt.name) != <span class="tok-null">null</span>) </span>
-<span class="line" id="L218">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Option '&quot;</span> ++ opt.name ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
-<span class="line" id="L219">                        distinct_name[idx] = opt.name;</span>
-<span class="line" id="L220">                        <span class="tok-kw">if</span> (opt.short_name != <span class="tok-null">null</span> <span class="tok-kw">and</span> indexOfEql(<span class="tok-type">u8</span>, distinct_short[<span class="tok-number">0</span>..], opt.short_name.?) != <span class="tok-null">null</span>) </span>
-<span class="line" id="L221">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Option Short Name '&quot;</span> ++ .{ opt.short_name.? } ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
-<span class="line" id="L222">                        distinct_short[idx] = opt.short_name.?;</span>
-<span class="line" id="L223">                        <span class="tok-kw">if</span> (opt.long_name != <span class="tok-null">null</span> <span class="tok-kw">and</span> indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_long[<span class="tok-number">0</span>..], opt.long_name.?) != <span class="tok-null">null</span>) </span>
-<span class="line" id="L224">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Option Long Name '&quot;</span> ++ opt.long_name.? ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
-<span class="line" id="L225">                        distinct_long[idx] = opt.long_name.?;</span>
-<span class="line" id="L226">                    }</span>
-<span class="line" id="L227">                }</span>
-<span class="line" id="L228"></span>
-<span class="line" id="L229">                <span class="tok-comment">// Check for distinct Values.</span>
+<span class="line" id="L229">                <span class="tok-kw">const</span> max_args = <span class="tok-number">100</span>;</span>
+<span class="line" id="L230">                <span class="tok-comment">// Check for distinct Sub Commands and Validate them.</span>
 </span>
-<span class="line" id="L230">                <span class="tok-kw">if</span> (self.vals != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L231">                    <span class="tok-kw">const</span> vals = self.vals.?;</span>
-<span class="line" id="L232">                    <span class="tok-kw">var</span> distinct_val: [<span class="tok-number">100</span>][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** <span class="tok-number">100</span>;</span>
-<span class="line" id="L233">                    <span class="tok-kw">for</span> (vals, <span class="tok-number">0</span>..) |val, idx| {</span>
-<span class="line" id="L234">                        <span class="tok-kw">if</span> (indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_val[<span class="tok-number">0</span>..], val.name()) != <span class="tok-null">null</span>) </span>
-<span class="line" id="L235">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Value '&quot;</span> ++ val.name ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
-<span class="line" id="L236">                        distinct_val[idx] = val.name();</span>
-<span class="line" id="L237">                    }</span>
-<span class="line" id="L238">                }</span>
-<span class="line" id="L239">            }</span>
-<span class="line" id="L240">        }</span>
-<span class="line" id="L241">    </span>
-<span class="line" id="L242">        <span class="tok-comment">/// Config for Setup of this Command.</span></span>
-<span class="line" id="L243">        <span class="tok-kw">const</span> SetupConfig = <span class="tok-kw">struct</span> {</span>
-<span class="line" id="L244">            <span class="tok-comment">/// Flag to Validate this Command.</span></span>
-<span class="line" id="L245">            validate_cmd: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
-<span class="line" id="L246">            <span class="tok-comment">/// Flag to add Usage/Help message Commands to this Command.</span></span>
-<span class="line" id="L247">            add_help_cmds: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
-<span class="line" id="L248">            <span class="tok-comment">/// Flag to add Usage/Help message Options to this Command.</span></span>
-<span class="line" id="L249">            add_help_opts: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
-<span class="line" id="L250">        };</span>
-<span class="line" id="L251"></span>
-<span class="line" id="L252">        <span class="tok-comment">/// Setup this Command during Comptime based on the provided SetupConfig.</span></span>
-<span class="line" id="L253">        <span class="tok-comment">/// (WIP) At this time, this functionality is rolled into `init()`. If I can figure out how to edit a struct instance at Comptime, it'll be moved to here.</span></span>
-<span class="line" id="L254">        <span class="tok-kw">fn</span> <span class="tok-fn">setup</span>(<span class="tok-kw">comptime</span> self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), <span class="tok-kw">comptime</span> setup_config: SetupConfig) <span class="tok-type">void</span> {</span>
-<span class="line" id="L255">            <span class="tok-kw">comptime</span> {</span>
-<span class="line" id="L256">                <span class="tok-kw">const</span> usage_description = <span class="tok-str">&quot;Show the '&quot;</span> ++ self.name ++ <span class="tok-str">&quot;' usage display.&quot;</span>;</span>
-<span class="line" id="L257">                <span class="tok-kw">const</span> help_description = <span class="tok-str">&quot;Show the '&quot;</span> ++ self.name ++ <span class="tok-str">&quot;' help display.&quot;</span>;</span>
-<span class="line" id="L258">                </span>
-<span class="line" id="L259">                <span class="tok-kw">if</span> (setup_config.add_help_cmds) {</span>
-<span class="line" id="L260">                    <span class="tok-kw">const</span> help_sub_cmds = [_]*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(){</span>
-<span class="line" id="L261">                        &amp;<span class="tok-builtin">@This</span>(){</span>
-<span class="line" id="L262">                            .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
-<span class="line" id="L263">                            .help_prefix = self.name,</span>
-<span class="line" id="L264">                            .description = usage_description, </span>
-<span class="line" id="L265">                        },</span>
-<span class="line" id="L266">                        &amp;<span class="tok-builtin">@This</span>(){</span>
-<span class="line" id="L267">                            .name = <span class="tok-str">&quot;help&quot;</span>,</span>
-<span class="line" id="L268">                            .help_prefix = self.name,</span>
-<span class="line" id="L269">                            .description = help_description, </span>
-<span class="line" id="L270">                        },</span>
-<span class="line" id="L271">                    };</span>
-<span class="line" id="L272">                    _ = help_sub_cmds;</span>
-<span class="line" id="L273"></span>
-<span class="line" id="L274">                    <span class="tok-builtin">@constCast</span>(self).sub_cmds = self.sub_cmds;<span class="tok-comment">//help_sub_cmds[0..];</span>
+<span class="line" id="L231">                <span class="tok-kw">if</span> (self.sub_cmds != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L232">                    <span class="tok-kw">const</span> cmds = self.sub_cmds.?;</span>
+<span class="line" id="L233">                    <span class="tok-kw">var</span> distinct_cmd: [max_args][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** max_args;</span>
+<span class="line" id="L234">                    <span class="tok-kw">for</span> (cmds, <span class="tok-number">0</span>..) |cmd, idx| {</span>
+<span class="line" id="L235">                        <span class="tok-kw">if</span> (indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_cmd[<span class="tok-number">0</span>..idx], cmd.name) != <span class="tok-null">null</span>) </span>
+<span class="line" id="L236">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Sub Command '&quot;</span> ++ cmd.name ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
+<span class="line" id="L237">                        <span class="tok-comment">//cmd.validate();</span>
 </span>
-<span class="line" id="L275">                        <span class="tok-comment">//if (self.sub_cmds != null) self.sub_cmds.? ++ help_sub_cmds[0..]</span>
+<span class="line" id="L238">                        distinct_cmd[idx] = cmd.name;</span>
+<span class="line" id="L239">                    }</span>
+<span class="line" id="L240">                }</span>
+<span class="line" id="L241"></span>
+<span class="line" id="L242">                <span class="tok-comment">// Check for distinct Options.</span>
 </span>
-<span class="line" id="L276">                        <span class="tok-comment">//else help_sub_cmds[0..];</span>
+<span class="line" id="L243">                <span class="tok-kw">if</span> (self.opts != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L244">                    <span class="tok-kw">const</span> opts = self.opts.?;</span>
+<span class="line" id="L245">                    <span class="tok-kw">var</span> distinct_name: [max_args][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** max_args;</span>
+<span class="line" id="L246">                    <span class="tok-kw">var</span> distinct_short: [max_args]<span class="tok-type">u8</span> = .{ <span class="tok-str">' '</span> } ** max_args;</span>
+<span class="line" id="L247">                    <span class="tok-kw">var</span> distinct_long: [max_args][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** max_args;</span>
+<span class="line" id="L248">                    <span class="tok-kw">for</span> (opts, <span class="tok-number">0</span>..) |opt, idx| {</span>
+<span class="line" id="L249">                        <span class="tok-kw">if</span> (indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_name[<span class="tok-number">0</span>..], opt.name) != <span class="tok-null">null</span>) </span>
+<span class="line" id="L250">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Option '&quot;</span> ++ opt.name ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
+<span class="line" id="L251">                        distinct_name[idx] = opt.name;</span>
+<span class="line" id="L252">                        <span class="tok-kw">if</span> (opt.short_name != <span class="tok-null">null</span> <span class="tok-kw">and</span> indexOfEql(<span class="tok-type">u8</span>, distinct_short[<span class="tok-number">0</span>..], opt.short_name.?) != <span class="tok-null">null</span>) </span>
+<span class="line" id="L253">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Option Short Name '&quot;</span> ++ .{ opt.short_name.? } ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
+<span class="line" id="L254">                        distinct_short[idx] = opt.short_name.?;</span>
+<span class="line" id="L255">                        <span class="tok-kw">if</span> (opt.long_name != <span class="tok-null">null</span> <span class="tok-kw">and</span> indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_long[<span class="tok-number">0</span>..], opt.long_name.?) != <span class="tok-null">null</span>) </span>
+<span class="line" id="L256">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Option Long Name '&quot;</span> ++ opt.long_name.? ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
+<span class="line" id="L257">                        distinct_long[idx] = opt.long_name.?;</span>
+<span class="line" id="L258">                    }</span>
+<span class="line" id="L259">                }</span>
+<span class="line" id="L260"></span>
+<span class="line" id="L261">                <span class="tok-comment">// Check for distinct Values.</span>
 </span>
-<span class="line" id="L277">                }</span>
-<span class="line" id="L278"></span>
-<span class="line" id="L279">                <span class="tok-kw">if</span> (setup_config.add_help_opts) {</span>
-<span class="line" id="L280">                    <span class="tok-kw">const</span> help_opts = [_]*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>().CustomOption{</span>
-<span class="line" id="L281">                        &amp;<span class="tok-builtin">@This</span>().CustomOption{</span>
-<span class="line" id="L282">                            .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
-<span class="line" id="L283">                            .short_name = <span class="tok-str">'u'</span>,</span>
-<span class="line" id="L284">                            .long_name = <span class="tok-str">&quot;usage&quot;</span>,</span>
-<span class="line" id="L285">                            .description = usage_description,</span>
-<span class="line" id="L286">                            .val = &amp;Val.init(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;usageFlag&quot;</span> }),</span>
-<span class="line" id="L287">                        },</span>
-<span class="line" id="L288">                        &amp;<span class="tok-builtin">@This</span>().CustomOption{</span>
-<span class="line" id="L289">                            .name = <span class="tok-str">&quot;help&quot;</span>,</span>
-<span class="line" id="L290">                            .short_name = <span class="tok-str">'h'</span>,</span>
-<span class="line" id="L291">                            .long_name = <span class="tok-str">&quot;help&quot;</span>,</span>
-<span class="line" id="L292">                            .description = help_description, </span>
-<span class="line" id="L293">                            .val = &amp;Val.init(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;helpFlag&quot;</span> }),</span>
-<span class="line" id="L294">                        },</span>
-<span class="line" id="L295">                    };</span>
-<span class="line" id="L296">                    self.opts = </span>
-<span class="line" id="L297">                        <span class="tok-kw">if</span> (self.opts != <span class="tok-null">null</span>) self.opts.? ++ help_opts[<span class="tok-number">0</span>..]</span>
-<span class="line" id="L298">                        <span class="tok-kw">else</span> help_opts[<span class="tok-number">0</span>..];</span>
-<span class="line" id="L299">                }</span>
-<span class="line" id="L300">                <span class="tok-kw">if</span> (setup_config.validate_cmd) self.validate();</span>
-<span class="line" id="L301">            }</span>
-<span class="line" id="L302">        }</span>
-<span class="line" id="L303"></span>
-<span class="line" id="L304">        <span class="tok-comment">/// Config for the Initialization of this Command.</span></span>
-<span class="line" id="L305">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> InitConfig = <span class="tok-kw">struct</span> {</span>
-<span class="line" id="L306">            <span class="tok-comment">/// Flag to Validate this Command.</span></span>
-<span class="line" id="L307">            validate_cmd: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
-<span class="line" id="L308">            <span class="tok-comment">/// Flag to add Usage/Help message Commands to this Command.</span></span>
-<span class="line" id="L309">            add_help_cmds: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
-<span class="line" id="L310">            <span class="tok-comment">/// Flag to add Usage/Help message Options to this Command.</span></span>
-<span class="line" id="L311">            add_help_opts: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
-<span class="line" id="L312">            <span class="tok-comment">/// Flag to initialize Sub Commands.</span></span>
-<span class="line" id="L313">            init_subcmds: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
-<span class="line" id="L314">        };</span>
-<span class="line" id="L315"></span>
-<span class="line" id="L316">        <span class="tok-comment">/// Initialize this Command with the provided Config by duplicating it with an Allocator for Runtime use.</span></span>
-<span class="line" id="L317">        <span class="tok-comment">/// This should be used after this Command has been created in Comptime. Notably, Validation is done during Comptime and must happen before usage/help Commands/Options are added.</span></span>
-<span class="line" id="L318">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">init</span>(<span class="tok-kw">comptime</span> self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), alloc: mem.Allocator, init_config: InitConfig) !*<span class="tok-builtin">@This</span>() {</span>
-<span class="line" id="L319">            <span class="tok-kw">if</span> (init_config.validate_cmd) self.validate();</span>
-<span class="line" id="L320"></span>
-<span class="line" id="L321">            <span class="tok-kw">const</span> init_cmd = &amp;(<span class="tok-kw">try</span> alloc.dupe(<span class="tok-builtin">@This</span>(), &amp;.{ self.* }))[<span class="tok-number">0</span>];</span>
-<span class="line" id="L322"></span>
-<span class="line" id="L323">            <span class="tok-kw">if</span> (init_config.init_subcmds <span class="tok-kw">and</span> self.sub_cmds != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L324">                <span class="tok-kw">var</span> init_subcmds = <span class="tok-kw">try</span> alloc.alloc(*<span class="tok-builtin">@This</span>(), self.sub_cmds.?.len);</span>
-<span class="line" id="L325">                <span class="tok-kw">inline</span> <span class="tok-kw">for</span> (self.sub_cmds.?, <span class="tok-number">0</span>..) |cmd, idx| init_subcmds[idx] = <span class="tok-kw">try</span> cmd.init(alloc, init_config); </span>
-<span class="line" id="L326">                init_cmd.sub_cmds = init_subcmds;</span>
-<span class="line" id="L327">            }</span>
-<span class="line" id="L328"></span>
-<span class="line" id="L329">            <span class="tok-kw">const</span> usage_description = <span class="tok-kw">try</span> mem.concat(alloc, <span class="tok-type">u8</span>, &amp;.{ <span class="tok-str">&quot;Show the '&quot;</span>, init_cmd.name, <span class="tok-str">&quot;' usage display.&quot;</span> });</span>
-<span class="line" id="L330">            <span class="tok-kw">const</span> help_description = <span class="tok-kw">try</span> mem.concat(alloc, <span class="tok-type">u8</span>, &amp;.{ <span class="tok-str">&quot;Show the '&quot;</span>, init_cmd.name, <span class="tok-str">&quot;' help display.&quot;</span> });</span>
-<span class="line" id="L331"></span>
-<span class="line" id="L332">            <span class="tok-kw">if</span> (init_config.add_help_cmds) {</span>
-<span class="line" id="L333">                <span class="tok-kw">var</span> help_sub_cmds = <span class="tok-kw">try</span> alloc.alloc(*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), <span class="tok-number">2</span>);</span>
-<span class="line" id="L334"></span>
-<span class="line" id="L335">                help_sub_cmds[<span class="tok-number">0</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>());</span>
-<span class="line" id="L336">                <span class="tok-builtin">@constCast</span>(help_sub_cmds[<span class="tok-number">0</span>]).* = .{</span>
-<span class="line" id="L337">                    .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
-<span class="line" id="L338">                    .help_prefix = init_cmd.name,</span>
-<span class="line" id="L339">                    .description = usage_description,</span>
-<span class="line" id="L340">                };</span>
-<span class="line" id="L341">                help_sub_cmds[<span class="tok-number">1</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>());</span>
-<span class="line" id="L342">                <span class="tok-builtin">@constCast</span>(help_sub_cmds[<span class="tok-number">1</span>]).* = .{</span>
-<span class="line" id="L343">                    .name = <span class="tok-str">&quot;help&quot;</span>,</span>
-<span class="line" id="L344">                    .help_prefix = init_cmd.name,</span>
-<span class="line" id="L345">                    .description = help_description,</span>
-<span class="line" id="L346">                };</span>
+<span class="line" id="L262">                <span class="tok-kw">if</span> (self.vals != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L263">                    <span class="tok-kw">const</span> vals = self.vals.?;</span>
+<span class="line" id="L264">                    <span class="tok-kw">var</span> distinct_val: [max_args][]<span class="tok-kw">const</span> <span class="tok-type">u8</span> = .{ <span class="tok-str">&quot;&quot;</span> } ** max_args;</span>
+<span class="line" id="L265">                    <span class="tok-kw">for</span> (vals, <span class="tok-number">0</span>..) |val, idx| {</span>
+<span class="line" id="L266">                        <span class="tok-kw">if</span> (indexOfEql([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>, distinct_val[<span class="tok-number">0</span>..], val.name()) != <span class="tok-null">null</span>) </span>
+<span class="line" id="L267">                            <span class="tok-builtin">@compileError</span>(<span class="tok-str">&quot;The Value '&quot;</span> ++ val.name ++ <span class="tok-str">&quot;' is set more than once.&quot;</span>);</span>
+<span class="line" id="L268">                        distinct_val[idx] = val.name();</span>
+<span class="line" id="L269">                    }</span>
+<span class="line" id="L270">                }</span>
+<span class="line" id="L271">            }</span>
+<span class="line" id="L272">        }</span>
+<span class="line" id="L273">    </span>
+<span class="line" id="L274">        <span class="tok-comment">/// Config for Setup of this Command.</span></span>
+<span class="line" id="L275">        <span class="tok-kw">const</span> SetupConfig = <span class="tok-kw">struct</span> {</span>
+<span class="line" id="L276">            <span class="tok-comment">/// Flag to Validate this Command.</span></span>
+<span class="line" id="L277">            validate_cmd: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L278">            <span class="tok-comment">/// Flag to add Usage/Help message Commands to this Command.</span></span>
+<span class="line" id="L279">            add_help_cmds: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L280">            <span class="tok-comment">/// Flag to add Usage/Help message Options to this Command.</span></span>
+<span class="line" id="L281">            add_help_opts: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L282">        };</span>
+<span class="line" id="L283"></span>
+<span class="line" id="L284">        <span class="tok-comment">/// Setup this Command during Comptime based on the provided SetupConfig.</span></span>
+<span class="line" id="L285">        <span class="tok-comment">/// (WIP) At this time, this functionality is rolled into `init()`. If I can figure out how to edit a struct instance at Comptime, it'll be moved to here.</span></span>
+<span class="line" id="L286">        <span class="tok-kw">fn</span> <span class="tok-fn">setup</span>(<span class="tok-kw">comptime</span> self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), <span class="tok-kw">comptime</span> setup_config: SetupConfig) <span class="tok-type">void</span> {</span>
+<span class="line" id="L287">            <span class="tok-kw">comptime</span> {</span>
+<span class="line" id="L288">                <span class="tok-kw">const</span> usage_description = <span class="tok-str">&quot;Show the '&quot;</span> ++ self.name ++ <span class="tok-str">&quot;' usage display.&quot;</span>;</span>
+<span class="line" id="L289">                <span class="tok-kw">const</span> help_description = <span class="tok-str">&quot;Show the '&quot;</span> ++ self.name ++ <span class="tok-str">&quot;' help display.&quot;</span>;</span>
+<span class="line" id="L290">                </span>
+<span class="line" id="L291">                <span class="tok-kw">if</span> (setup_config.add_help_cmds) {</span>
+<span class="line" id="L292">                    <span class="tok-kw">const</span> help_sub_cmds = [_]*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(){</span>
+<span class="line" id="L293">                        &amp;<span class="tok-builtin">@This</span>(){</span>
+<span class="line" id="L294">                            .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
+<span class="line" id="L295">                            .help_prefix = self.name,</span>
+<span class="line" id="L296">                            .description = usage_description, </span>
+<span class="line" id="L297">                        },</span>
+<span class="line" id="L298">                        &amp;<span class="tok-builtin">@This</span>(){</span>
+<span class="line" id="L299">                            .name = <span class="tok-str">&quot;help&quot;</span>,</span>
+<span class="line" id="L300">                            .help_prefix = self.name,</span>
+<span class="line" id="L301">                            .description = help_description, </span>
+<span class="line" id="L302">                        },</span>
+<span class="line" id="L303">                    };</span>
+<span class="line" id="L304">                    _ = help_sub_cmds;</span>
+<span class="line" id="L305"></span>
+<span class="line" id="L306">                    <span class="tok-builtin">@constCast</span>(self).sub_cmds = self.sub_cmds;<span class="tok-comment">//help_sub_cmds[0..];</span>
+</span>
+<span class="line" id="L307">                        <span class="tok-comment">//if (self.sub_cmds != null) self.sub_cmds.? ++ help_sub_cmds[0..]</span>
+</span>
+<span class="line" id="L308">                        <span class="tok-comment">//else help_sub_cmds[0..];</span>
+</span>
+<span class="line" id="L309">                }</span>
+<span class="line" id="L310"></span>
+<span class="line" id="L311">                <span class="tok-kw">if</span> (setup_config.add_help_opts) {</span>
+<span class="line" id="L312">                    <span class="tok-kw">const</span> help_opts = [_]*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>().CustomOption{</span>
+<span class="line" id="L313">                        &amp;<span class="tok-builtin">@This</span>().CustomOption{</span>
+<span class="line" id="L314">                            .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
+<span class="line" id="L315">                            .short_name = <span class="tok-str">'u'</span>,</span>
+<span class="line" id="L316">                            .long_name = <span class="tok-str">&quot;usage&quot;</span>,</span>
+<span class="line" id="L317">                            .description = usage_description,</span>
+<span class="line" id="L318">                            .val = &amp;Value.ofType(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;usageFlag&quot;</span> }),</span>
+<span class="line" id="L319">                        },</span>
+<span class="line" id="L320">                        &amp;<span class="tok-builtin">@This</span>().CustomOption{</span>
+<span class="line" id="L321">                            .name = <span class="tok-str">&quot;help&quot;</span>,</span>
+<span class="line" id="L322">                            .short_name = <span class="tok-str">'h'</span>,</span>
+<span class="line" id="L323">                            .long_name = <span class="tok-str">&quot;help&quot;</span>,</span>
+<span class="line" id="L324">                            .description = help_description, </span>
+<span class="line" id="L325">                            .val = &amp;Value.ofType(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;helpFlag&quot;</span> }),</span>
+<span class="line" id="L326">                        },</span>
+<span class="line" id="L327">                    };</span>
+<span class="line" id="L328">                    self.opts = </span>
+<span class="line" id="L329">                        <span class="tok-kw">if</span> (self.opts != <span class="tok-null">null</span>) self.opts.? ++ help_opts[<span class="tok-number">0</span>..]</span>
+<span class="line" id="L330">                        <span class="tok-kw">else</span> help_opts[<span class="tok-number">0</span>..];</span>
+<span class="line" id="L331">                }</span>
+<span class="line" id="L332">                <span class="tok-kw">if</span> (setup_config.validate_cmd) self.validate();</span>
+<span class="line" id="L333">            }</span>
+<span class="line" id="L334">        }</span>
+<span class="line" id="L335"></span>
+<span class="line" id="L336">        <span class="tok-comment">/// Config for the Initialization of this Command.</span></span>
+<span class="line" id="L337">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> InitConfig = <span class="tok-kw">struct</span> {</span>
+<span class="line" id="L338">            <span class="tok-comment">/// Flag to Validate this Command.</span></span>
+<span class="line" id="L339">            validate_cmd: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L340">            <span class="tok-comment">/// Flag to add Usage/Help message Commands to this Command.</span></span>
+<span class="line" id="L341">            add_help_cmds: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L342">            <span class="tok-comment">/// Flag to add Usage/Help message Options to this Command.</span></span>
+<span class="line" id="L343">            add_help_opts: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L344">            <span class="tok-comment">/// Flag to initialize Sub Commands.</span></span>
+<span class="line" id="L345">            init_subcmds: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L346">        };</span>
 <span class="line" id="L347"></span>
-<span class="line" id="L348">                <span class="tok-builtin">@constCast</span>(init_cmd).sub_cmds = </span>
-<span class="line" id="L349">                    <span class="tok-kw">if</span> (init_cmd.sub_cmds != <span class="tok-null">null</span>) <span class="tok-kw">try</span> mem.concat(alloc, *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), &amp;.{ init_cmd.sub_cmds.?, help_sub_cmds[<span class="tok-number">0</span>..] })</span>
-<span class="line" id="L350">                    <span class="tok-kw">else</span> help_sub_cmds[<span class="tok-number">0</span>..];</span>
-<span class="line" id="L351">            }</span>
+<span class="line" id="L348">        <span class="tok-comment">/// Initialize this Command with the provided Config by duplicating it with an Allocator for Runtime use.</span></span>
+<span class="line" id="L349">        <span class="tok-comment">/// This should be used after this Command has been created in Comptime. Notably, Validation is done during Comptime and must happen before usage/help Commands/Options are added.</span></span>
+<span class="line" id="L350">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">init</span>(<span class="tok-kw">comptime</span> self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), alloc: mem.Allocator, init_config: InitConfig) !*<span class="tok-builtin">@This</span>() {</span>
+<span class="line" id="L351">            <span class="tok-kw">if</span> (init_config.validate_cmd) self.validate();</span>
 <span class="line" id="L352"></span>
-<span class="line" id="L353">            <span class="tok-kw">if</span> (init_config.add_help_opts) {</span>
-<span class="line" id="L354">                <span class="tok-kw">var</span> help_opts = <span class="tok-kw">try</span> alloc.alloc(*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>().CustomOption, <span class="tok-number">2</span>);</span>
-<span class="line" id="L355">                help_opts[<span class="tok-number">0</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>().CustomOption);</span>
-<span class="line" id="L356">                <span class="tok-builtin">@constCast</span>(help_opts[<span class="tok-number">0</span>]).* = .{</span>
-<span class="line" id="L357">                    .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
-<span class="line" id="L358">                    .short_name = <span class="tok-str">'u'</span>,</span>
-<span class="line" id="L359">                    .long_name = <span class="tok-str">&quot;usage&quot;</span>,</span>
-<span class="line" id="L360">                    .description = usage_description,</span>
-<span class="line" id="L361">                    .val = usageVal: {</span>
-<span class="line" id="L362">                        <span class="tok-kw">var</span> usage_val = <span class="tok-kw">try</span> alloc.create(Val.Generic);</span>
-<span class="line" id="L363">                        usage_val.* = Val.init(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;usageFlag&quot;</span> });</span>
-<span class="line" id="L364">                        <span class="tok-kw">break</span> :usageVal usage_val;</span>
-<span class="line" id="L365">                    },</span>
-<span class="line" id="L366">                };</span>
-<span class="line" id="L367">                help_opts[<span class="tok-number">1</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>().CustomOption);</span>
-<span class="line" id="L368">                <span class="tok-builtin">@constCast</span>(help_opts[<span class="tok-number">1</span>]).* = .{</span>
-<span class="line" id="L369">		    .name = <span class="tok-str">&quot;help&quot;</span>,</span>
-<span class="line" id="L370">                    .short_name = <span class="tok-str">'h'</span>,</span>
-<span class="line" id="L371">                    .long_name = <span class="tok-str">&quot;help&quot;</span>,</span>
-<span class="line" id="L372">                    .description = help_description,</span>
-<span class="line" id="L373">                    .val = helpVal: {</span>
-<span class="line" id="L374">                        <span class="tok-kw">var</span> help_val = <span class="tok-kw">try</span> alloc.create(Val.Generic);</span>
-<span class="line" id="L375">                        help_val.* = Val.init(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;helpFlag&quot;</span> });</span>
-<span class="line" id="L376">                        <span class="tok-kw">break</span> :helpVal help_val;</span>
-<span class="line" id="L377">                    },</span>
+<span class="line" id="L353">            <span class="tok-kw">const</span> init_cmd = &amp;(<span class="tok-kw">try</span> alloc.dupe(<span class="tok-builtin">@This</span>(), &amp;.{ self.* }))[<span class="tok-number">0</span>];</span>
+<span class="line" id="L354"></span>
+<span class="line" id="L355">            <span class="tok-kw">if</span> (init_config.init_subcmds <span class="tok-kw">and</span> self.sub_cmds != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L356">                <span class="tok-kw">var</span> init_subcmds = <span class="tok-kw">try</span> alloc.alloc(*<span class="tok-builtin">@This</span>(), self.sub_cmds.?.len);</span>
+<span class="line" id="L357">                <span class="tok-kw">inline</span> <span class="tok-kw">for</span> (self.sub_cmds.?, <span class="tok-number">0</span>..) |cmd, idx| init_subcmds[idx] = <span class="tok-kw">try</span> cmd.init(alloc, init_config); </span>
+<span class="line" id="L358">                init_cmd.sub_cmds = init_subcmds;</span>
+<span class="line" id="L359">            }</span>
+<span class="line" id="L360"></span>
+<span class="line" id="L361">            <span class="tok-kw">const</span> usage_description = <span class="tok-kw">try</span> mem.concat(alloc, <span class="tok-type">u8</span>, &amp;.{ <span class="tok-str">&quot;Show the '&quot;</span>, init_cmd.name, <span class="tok-str">&quot;' usage display.&quot;</span> });</span>
+<span class="line" id="L362">            <span class="tok-kw">const</span> help_description = <span class="tok-kw">try</span> mem.concat(alloc, <span class="tok-type">u8</span>, &amp;.{ <span class="tok-str">&quot;Show the '&quot;</span>, init_cmd.name, <span class="tok-str">&quot;' help display.&quot;</span> });</span>
+<span class="line" id="L363"></span>
+<span class="line" id="L364">            <span class="tok-kw">if</span> (init_config.add_help_cmds) {</span>
+<span class="line" id="L365">                <span class="tok-kw">var</span> help_sub_cmds = <span class="tok-kw">try</span> alloc.alloc(*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), <span class="tok-number">2</span>);</span>
+<span class="line" id="L366"></span>
+<span class="line" id="L367">                help_sub_cmds[<span class="tok-number">0</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>());</span>
+<span class="line" id="L368">                <span class="tok-builtin">@constCast</span>(help_sub_cmds[<span class="tok-number">0</span>]).* = .{</span>
+<span class="line" id="L369">                    .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
+<span class="line" id="L370">                    .help_prefix = init_cmd.name,</span>
+<span class="line" id="L371">                    .description = usage_description,</span>
+<span class="line" id="L372">                };</span>
+<span class="line" id="L373">                help_sub_cmds[<span class="tok-number">1</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>());</span>
+<span class="line" id="L374">                <span class="tok-builtin">@constCast</span>(help_sub_cmds[<span class="tok-number">1</span>]).* = .{</span>
+<span class="line" id="L375">                    .name = <span class="tok-str">&quot;help&quot;</span>,</span>
+<span class="line" id="L376">                    .help_prefix = init_cmd.name,</span>
+<span class="line" id="L377">                    .description = help_description,</span>
 <span class="line" id="L378">                };</span>
 <span class="line" id="L379"></span>
-<span class="line" id="L380">                <span class="tok-builtin">@constCast</span>(init_cmd).opts = </span>
-<span class="line" id="L381">                    <span class="tok-kw">if</span> (init_cmd.opts != <span class="tok-null">null</span>) <span class="tok-kw">try</span> mem.concat(alloc, *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>().CustomOption, &amp;.{ init_cmd.opts.?, help_opts[<span class="tok-number">0</span>..] })</span>
-<span class="line" id="L382">                    <span class="tok-kw">else</span> help_opts[<span class="tok-number">0</span>..];</span>
+<span class="line" id="L380">                <span class="tok-builtin">@constCast</span>(init_cmd).sub_cmds = </span>
+<span class="line" id="L381">                    <span class="tok-kw">if</span> (init_cmd.sub_cmds != <span class="tok-null">null</span>) <span class="tok-kw">try</span> mem.concat(alloc, *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), &amp;.{ init_cmd.sub_cmds.?, help_sub_cmds[<span class="tok-number">0</span>..] })</span>
+<span class="line" id="L382">                    <span class="tok-kw">else</span> help_sub_cmds[<span class="tok-number">0</span>..];</span>
 <span class="line" id="L383">            }</span>
 <span class="line" id="L384"></span>
-<span class="line" id="L385">            <span class="tok-kw">return</span> init_cmd; </span>
-<span class="line" id="L386">        }</span>
-<span class="line" id="L387"></span>
-<span class="line" id="L388">        <span class="tok-comment">/// De-initialize this Command with its original Allocator.</span></span>
-<span class="line" id="L389">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">deinit</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), alloc: mem.Allocator) <span class="tok-type">void</span> {</span>
-<span class="line" id="L390">            alloc.destroy(self);</span>
-<span class="line" id="L391">        }</span>
-<span class="line" id="L392">    };</span>
-<span class="line" id="L393"></span>
-<span class="line" id="L394">}</span>
-<span class="line" id="L395"></span>
-<span class="line" id="L396"></span>
+<span class="line" id="L385">            <span class="tok-kw">if</span> (init_config.add_help_opts) {</span>
+<span class="line" id="L386">                <span class="tok-kw">var</span> help_opts = <span class="tok-kw">try</span> alloc.alloc(*<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>().CustomOption, <span class="tok-number">2</span>);</span>
+<span class="line" id="L387">                help_opts[<span class="tok-number">0</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>().CustomOption);</span>
+<span class="line" id="L388">                <span class="tok-builtin">@constCast</span>(help_opts[<span class="tok-number">0</span>]).* = .{</span>
+<span class="line" id="L389">                    .name = <span class="tok-str">&quot;usage&quot;</span>,</span>
+<span class="line" id="L390">                    .short_name = <span class="tok-str">'u'</span>,</span>
+<span class="line" id="L391">                    .long_name = <span class="tok-str">&quot;usage&quot;</span>,</span>
+<span class="line" id="L392">                    .description = usage_description,</span>
+<span class="line" id="L393">                    .val = usageVal: {</span>
+<span class="line" id="L394">                        <span class="tok-kw">var</span> usage_val = <span class="tok-kw">try</span> alloc.create(Value.Generic);</span>
+<span class="line" id="L395">                        usage_val.* = Value.ofType(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;usageFlag&quot;</span> });</span>
+<span class="line" id="L396">                        <span class="tok-kw">break</span> :usageVal usage_val;</span>
+<span class="line" id="L397">                    },</span>
+<span class="line" id="L398">                };</span>
+<span class="line" id="L399">                help_opts[<span class="tok-number">1</span>] = <span class="tok-kw">try</span> alloc.create(<span class="tok-builtin">@This</span>().CustomOption);</span>
+<span class="line" id="L400">                <span class="tok-builtin">@constCast</span>(help_opts[<span class="tok-number">1</span>]).* = .{</span>
+<span class="line" id="L401">		    .name = <span class="tok-str">&quot;help&quot;</span>,</span>
+<span class="line" id="L402">                    .short_name = <span class="tok-str">'h'</span>,</span>
+<span class="line" id="L403">                    .long_name = <span class="tok-str">&quot;help&quot;</span>,</span>
+<span class="line" id="L404">                    .description = help_description,</span>
+<span class="line" id="L405">                    .val = helpVal: {</span>
+<span class="line" id="L406">                        <span class="tok-kw">var</span> help_val = <span class="tok-kw">try</span> alloc.create(Value.Generic);</span>
+<span class="line" id="L407">                        help_val.* = Value.ofType(<span class="tok-type">bool</span>, .{ .name = <span class="tok-str">&quot;helpFlag&quot;</span> });</span>
+<span class="line" id="L408">                        <span class="tok-kw">break</span> :helpVal help_val;</span>
+<span class="line" id="L409">                    },</span>
+<span class="line" id="L410">                };</span>
+<span class="line" id="L411"></span>
+<span class="line" id="L412">                <span class="tok-builtin">@constCast</span>(init_cmd).opts = </span>
+<span class="line" id="L413">                    <span class="tok-kw">if</span> (init_cmd.opts != <span class="tok-null">null</span>) <span class="tok-kw">try</span> mem.concat(alloc, *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>().CustomOption, &amp;.{ init_cmd.opts.?, help_opts[<span class="tok-number">0</span>..] })</span>
+<span class="line" id="L414">                    <span class="tok-kw">else</span> help_opts[<span class="tok-number">0</span>..];</span>
+<span class="line" id="L415">            }</span>
+<span class="line" id="L416"></span>
+<span class="line" id="L417">            <span class="tok-kw">return</span> init_cmd; </span>
+<span class="line" id="L418">        }</span>
+<span class="line" id="L419"></span>
+<span class="line" id="L420">        <span class="tok-comment">/// De-initialize this Command with its original Allocator.</span></span>
+<span class="line" id="L421">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">deinit</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), alloc: mem.Allocator) <span class="tok-type">void</span> {</span>
+<span class="line" id="L422">            alloc.destroy(self);</span>
+<span class="line" id="L423">        }</span>
+<span class="line" id="L424">    };</span>
+<span class="line" id="L425">}</span>
+<span class="line" id="L426"></span>
+<span class="line" id="L427"></span>
 </code></pre></body>
 </html>

--- a/docs/src/cova/Option.zig.html
+++ b/docs/src/cova/Option.zig.html
@@ -125,9 +125,9 @@
 <span class="line" id="L12"><span class="tok-kw">const</span> std = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;std&quot;</span>);</span>
 <span class="line" id="L13"><span class="tok-kw">const</span> ascii = std.ascii;</span>
 <span class="line" id="L14"></span>
-<span class="line" id="L15"><span class="tok-kw">const</span> toUpper = ascii.upperString;</span>
+<span class="line" id="L15"><span class="tok-kw">const</span> toUpper = ascii.toUpper;</span>
 <span class="line" id="L16"></span>
-<span class="line" id="L17"><span class="tok-kw">const</span> Val = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;Value.zig&quot;</span>);</span>
+<span class="line" id="L17"><span class="tok-kw">const</span> Value = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;Value.zig&quot;</span>);</span>
 <span class="line" id="L18">    </span>
 <span class="line" id="L19"><span class="tok-comment">/// Config for custom Option types.</span></span>
 <span class="line" id="L20"><span class="tok-kw">pub</span> <span class="tok-kw">const</span> Config = <span class="tok-kw">struct</span> {</span>
@@ -162,55 +162,58 @@
 <span class="line" id="L49">        <span class="tok-comment">/// This Option's Long Name (ex: `--intOpt`).</span></span>
 <span class="line" id="L50">        long_name: ?[]<span class="tok-kw">const</span> <span class="tok-type">u8</span>,</span>
 <span class="line" id="L51">        <span class="tok-comment">/// This Option's wrapped Value.</span></span>
-<span class="line" id="L52">        val: *<span class="tok-kw">const</span> Val.Generic = &amp;Val.init(<span class="tok-type">bool</span>, .{}),</span>
+<span class="line" id="L52">        val: *<span class="tok-kw">const</span> Value.Generic = &amp;Value.ofType(<span class="tok-type">bool</span>, .{}),</span>
 <span class="line" id="L53"></span>
 <span class="line" id="L54">        <span class="tok-comment">/// The Name of this Option for user identification and Usage/Help messages.</span></span>
-<span class="line" id="L55">        name: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>,</span>
-<span class="line" id="L56">        <span class="tok-comment">/// The Description of this Option for Usage/Help messages.</span></span>
-<span class="line" id="L57">        description: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;&quot;</span>,</span>
-<span class="line" id="L58"></span>
-<span class="line" id="L59">        <span class="tok-comment">/// Help Format.</span></span>
-<span class="line" id="L60">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
-<span class="line" id="L61">        <span class="tok-kw">const</span> help_fmt = config.help_fmt;</span>
-<span class="line" id="L62">        <span class="tok-comment">/// Usage Format.</span></span>
-<span class="line" id="L63">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
-<span class="line" id="L64">        <span class="tok-kw">const</span> usage_fmt = config.usage_fmt;</span>
-<span class="line" id="L65"></span>
-<span class="line" id="L66">        <span class="tok-comment">/// Short Prefix.</span></span>
-<span class="line" id="L67">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
-<span class="line" id="L68">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> short_prefix = config.short_prefix;</span>
-<span class="line" id="L69">        <span class="tok-comment">/// Long Prefix. </span></span>
-<span class="line" id="L70">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
-<span class="line" id="L71">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> long_prefix = config.long_prefix;</span>
-<span class="line" id="L72"></span>
-<span class="line" id="L73">        <span class="tok-comment">/// Creates the Help message for this Option and Writes it to the provided Writer.</span></span>
-<span class="line" id="L74">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">help</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), writer: <span class="tok-kw">anytype</span>) !<span class="tok-type">void</span> {</span>
-<span class="line" id="L75">            <span class="tok-kw">var</span> upper_name_buf: [<span class="tok-number">100</span>]<span class="tok-type">u8</span> = <span class="tok-null">undefined</span>;</span>
-<span class="line" id="L76">            <span class="tok-kw">var</span> upper_name = toUpper(upper_name_buf[<span class="tok-number">0</span>..], self.name);</span>
-<span class="line" id="L77">            <span class="tok-kw">if</span> (help_fmt == <span class="tok-null">null</span>) {</span>
-<span class="line" id="L78">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;{s}:\n            &quot;</span>, .{ upper_name });</span>
-<span class="line" id="L79">                <span class="tok-kw">try</span> self.usage(writer);</span>
-<span class="line" id="L80">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n            {s}&quot;</span>, .{ self.description });</span>
-<span class="line" id="L81">                <span class="tok-kw">return</span>;</span>
-<span class="line" id="L82">            }</span>
-<span class="line" id="L83">            <span class="tok-kw">try</span> writer.print(help_fmt.?, .{ upper_name, self.description });</span>
-<span class="line" id="L84">        }</span>
-<span class="line" id="L85"></span>
-<span class="line" id="L86">        <span class="tok-comment">/// Creates the Usage message for this Option and Writes it to the provided Writer.</span></span>
-<span class="line" id="L87">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">usage</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), writer: <span class="tok-kw">anytype</span>) !<span class="tok-type">void</span> {</span>
-<span class="line" id="L88">            <span class="tok-kw">try</span> writer.print(usage_fmt, .{ </span>
-<span class="line" id="L89">                short_prefix,</span>
-<span class="line" id="L90">                self.short_name,</span>
-<span class="line" id="L91">                long_prefix,</span>
-<span class="line" id="L92">                self.long_name,</span>
-<span class="line" id="L93">                self.val.name(),</span>
-<span class="line" id="L94">                self.val.valType(),</span>
-<span class="line" id="L95">            });</span>
-<span class="line" id="L96">        }</span>
-<span class="line" id="L97">    };</span>
-<span class="line" id="L98">} </span>
-<span class="line" id="L99"></span>
-<span class="line" id="L100"></span>
-<span class="line" id="L101"></span>
+<span class="line" id="L55">        <span class="tok-comment">/// Limited to 100B.</span></span>
+<span class="line" id="L56">        name: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>,</span>
+<span class="line" id="L57">        <span class="tok-comment">/// The Description of this Option for Usage/Help messages.</span></span>
+<span class="line" id="L58">        description: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;&quot;</span>,</span>
+<span class="line" id="L59"></span>
+<span class="line" id="L60">        <span class="tok-comment">/// Help Format.</span></span>
+<span class="line" id="L61">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
+<span class="line" id="L62">        <span class="tok-kw">const</span> help_fmt = config.help_fmt;</span>
+<span class="line" id="L63">        <span class="tok-comment">/// Usage Format.</span></span>
+<span class="line" id="L64">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
+<span class="line" id="L65">        <span class="tok-kw">const</span> usage_fmt = config.usage_fmt;</span>
+<span class="line" id="L66"></span>
+<span class="line" id="L67">        <span class="tok-comment">/// Short Prefix.</span></span>
+<span class="line" id="L68">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
+<span class="line" id="L69">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> short_prefix = config.short_prefix;</span>
+<span class="line" id="L70">        <span class="tok-comment">/// Long Prefix. </span></span>
+<span class="line" id="L71">        <span class="tok-comment">/// Check `Options.Config` for details.</span></span>
+<span class="line" id="L72">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> long_prefix = config.long_prefix;</span>
+<span class="line" id="L73"></span>
+<span class="line" id="L74">        <span class="tok-comment">/// Creates the Help message for this Option and Writes it to the provided Writer.</span></span>
+<span class="line" id="L75">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">help</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), writer: <span class="tok-kw">anytype</span>) !<span class="tok-type">void</span> {</span>
+<span class="line" id="L76">            <span class="tok-kw">var</span> upper_name_buf: [<span class="tok-number">100</span>]<span class="tok-type">u8</span> = <span class="tok-null">undefined</span>;</span>
+<span class="line" id="L77">            <span class="tok-kw">const</span> upper_name = upper_name_buf[<span class="tok-number">0</span>..];</span>
+<span class="line" id="L78">            upper_name[<span class="tok-number">0</span>] = toUpper(self.name[<span class="tok-number">0</span>]);</span>
+<span class="line" id="L79">            <span class="tok-kw">for</span>(upper_name[<span class="tok-number">1</span>..self.name.len], <span class="tok-number">1</span>..) |*c, i| c.* = self.name[i];</span>
+<span class="line" id="L80">            <span class="tok-kw">if</span> (help_fmt == <span class="tok-null">null</span>) {</span>
+<span class="line" id="L81">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;{s}:\n            &quot;</span>, .{ upper_name });</span>
+<span class="line" id="L82">                <span class="tok-kw">try</span> self.usage(writer);</span>
+<span class="line" id="L83">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n            {s}&quot;</span>, .{ self.description });</span>
+<span class="line" id="L84">                <span class="tok-kw">return</span>;</span>
+<span class="line" id="L85">            }</span>
+<span class="line" id="L86">            <span class="tok-kw">try</span> writer.print(help_fmt.?, .{ upper_name, self.description });</span>
+<span class="line" id="L87">        }</span>
+<span class="line" id="L88"></span>
+<span class="line" id="L89">        <span class="tok-comment">/// Creates the Usage message for this Option and Writes it to the provided Writer.</span></span>
+<span class="line" id="L90">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">usage</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), writer: <span class="tok-kw">anytype</span>) !<span class="tok-type">void</span> {</span>
+<span class="line" id="L91">            <span class="tok-kw">try</span> writer.print(usage_fmt, .{ </span>
+<span class="line" id="L92">                short_prefix,</span>
+<span class="line" id="L93">                self.short_name,</span>
+<span class="line" id="L94">                long_prefix,</span>
+<span class="line" id="L95">                self.long_name,</span>
+<span class="line" id="L96">                self.val.name(),</span>
+<span class="line" id="L97">                self.val.valType(),</span>
+<span class="line" id="L98">            });</span>
+<span class="line" id="L99">        }</span>
+<span class="line" id="L100">    };</span>
+<span class="line" id="L101">} </span>
+<span class="line" id="L102"></span>
+<span class="line" id="L103"></span>
+<span class="line" id="L104"></span>
 </code></pre></body>
 </html>

--- a/docs/src/cova/Value.zig.html
+++ b/docs/src/cova/Value.zig.html
@@ -136,172 +136,216 @@
 <span class="line" id="L23"><span class="tok-kw">const</span> Type = builtin.Type;</span>
 <span class="line" id="L24"><span class="tok-kw">const</span> UnionField = Type.UnionField;</span>
 <span class="line" id="L25"></span>
-<span class="line" id="L26"></span>
-<span class="line" id="L27"><span class="tok-comment">/// Create a Value with a specific Type.</span></span>
-<span class="line" id="L28"><span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">Typed</span>(<span class="tok-kw">comptime</span> set_type: <span class="tok-type">type</span>) <span class="tok-type">type</span> {</span>
-<span class="line" id="L29">    <span class="tok-kw">return</span> <span class="tok-kw">struct</span> {</span>
-<span class="line" id="L30">        <span class="tok-comment">/// The inner Type of this Value.</span></span>
-<span class="line" id="L31">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> val_type = set_type;</span>
-<span class="line" id="L32"></span>
-<span class="line" id="L33">        <span class="tok-comment">/// The Raw Argument provided to this Value for Parsing and Validation.</span></span>
-<span class="line" id="L34">        raw_arg: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;&quot;</span>,</span>
-<span class="line" id="L35">        <span class="tok-comment">/// An optional Default Value.</span></span>
-<span class="line" id="L36">        default_val: ?val_type = <span class="tok-null">null</span>,</span>
-<span class="line" id="L37">        <span class="tok-comment">/// Flag to determine if this Value has been Parsed and Validated.</span></span>
-<span class="line" id="L38">        is_set: <span class="tok-type">bool</span> = <span class="tok-null">false</span>,</span>
-<span class="line" id="L39">        <span class="tok-comment">/// A Validation Function to be used in set() following normal Parsing.</span></span>
-<span class="line" id="L40">        val_fn: ?*<span class="tok-kw">const</span> <span class="tok-kw">fn</span>(val_type) <span class="tok-type">bool</span> = <span class="tok-kw">struct</span>{ <span class="tok-kw">fn</span> <span class="tok-fn">valFn</span>(val: val_type) <span class="tok-type">bool</span> { <span class="tok-kw">return</span> <span class="tok-builtin">@TypeOf</span>(val) == val_type; } }.valFn,</span>
-<span class="line" id="L41">            </span>
-<span class="line" id="L42">        <span class="tok-comment">/// The Name of this Value for user identification and Usage/Help messages.</span></span>
-<span class="line" id="L43">        name: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;&quot;</span>,</span>
-<span class="line" id="L44">        <span class="tok-comment">/// The Description of this Value for Usage/Help messages.</span></span>
-<span class="line" id="L45">        description: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;&quot;</span>,</span>
-<span class="line" id="L46"></span>
-<span class="line" id="L47">        <span class="tok-comment">/// Parse the given Argument to this Value's Type.</span></span>
-<span class="line" id="L48">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">parse</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), arg: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) !val_type {</span>
-<span class="line" id="L49">            _ = self;</span>
-<span class="line" id="L50">            <span class="tok-kw">var</span> san_arg_buf: [<span class="tok-number">100</span>]<span class="tok-type">u8</span> = <span class="tok-null">undefined</span>;</span>
-<span class="line" id="L51">            <span class="tok-kw">const</span> san_arg = toLower(san_arg_buf[<span class="tok-number">0</span>..], arg);</span>
-<span class="line" id="L52">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (<span class="tok-builtin">@typeInfo</span>(val_type)) {</span>
-<span class="line" id="L53">                <span class="tok-comment">//.Null =&gt; error.ValueNotSet,</span>
+<span class="line" id="L26"><span class="tok-comment">/// The Behavior for Setting Values.</span></span>
+<span class="line" id="L27"><span class="tok-comment">/// These are currently only implemented for Values that are within Options.</span></span>
+<span class="line" id="L28"><span class="tok-kw">pub</span> <span class="tok-kw">const</span> SetBehavior = <span class="tok-kw">enum</span> {</span>
+<span class="line" id="L29">    <span class="tok-comment">/// Keeps the First Argument this Value was Set to.</span></span>
+<span class="line" id="L30">    First,</span>
+<span class="line" id="L31">    <span class="tok-comment">/// Keeps the Last Argument this Value was Set to.</span></span>
+<span class="line" id="L32">    Last,</span>
+<span class="line" id="L33">    <span class="tok-comment">/// Keeps Multiple Arguments in this Value up to the set Max.</span></span>
+<span class="line" id="L34">    Multi,</span>
+<span class="line" id="L35">};</span>
+<span class="line" id="L36"></span>
+<span class="line" id="L37"><span class="tok-comment">/// Create a Value with a specific Type.</span></span>
+<span class="line" id="L38"><span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">Typed</span>(<span class="tok-kw">comptime</span> set_type: <span class="tok-type">type</span>) <span class="tok-type">type</span> {</span>
+<span class="line" id="L39">    <span class="tok-kw">return</span> <span class="tok-kw">struct</span> {</span>
+<span class="line" id="L40">        <span class="tok-comment">/// The inner Type of this Value.</span></span>
+<span class="line" id="L41">        <span class="tok-kw">pub</span> <span class="tok-kw">const</span> val_type = set_type;</span>
+<span class="line" id="L42"></span>
+<span class="line" id="L43">        <span class="tok-comment">/// The Parsed and Validated Argument(s) this Value has been set to.</span></span>
+<span class="line" id="L44">        <span class="tok-comment">/// Internal Use.</span></span>
+<span class="line" id="L45">        _set_args: [<span class="tok-number">100</span>]?val_type = .{ <span class="tok-null">null</span> } ** <span class="tok-number">100</span>,</span>
+<span class="line" id="L46">        <span class="tok-comment">/// The current Index of Raw Arguments for this Value.</span></span>
+<span class="line" id="L47">        <span class="tok-comment">/// Internal Use.</span></span>
+<span class="line" id="L48">        _arg_idx: <span class="tok-type">u7</span> = <span class="tok-number">0</span>,</span>
+<span class="line" id="L49">        <span class="tok-comment">/// The Max number of Raw Arguments that can be provided.</span></span>
+<span class="line" id="L50">        <span class="tok-comment">/// This must be between 1 - 100.</span></span>
+<span class="line" id="L51">        max_args: <span class="tok-type">u7</span> = <span class="tok-number">1</span>,</span>
+<span class="line" id="L52">        <span class="tok-comment">/// Set Behavior for this Value.</span></span>
+<span class="line" id="L53">        set_behavior: SetBehavior = .Last,</span>
+<span class="line" id="L54">        <span class="tok-comment">/// An optional Default Value.</span></span>
+<span class="line" id="L55">        default_val: ?val_type = <span class="tok-null">null</span>,</span>
+<span class="line" id="L56">        <span class="tok-comment">/// Flag to determine if this Value has been Parsed and Validated.</span></span>
+<span class="line" id="L57">        is_set: <span class="tok-type">bool</span> = <span class="tok-null">false</span>,</span>
+<span class="line" id="L58">        <span class="tok-comment">/// A Validation Function to be used in `set()` following normal Parsing.</span></span>
+<span class="line" id="L59">        val_fn: ?*<span class="tok-kw">const</span> <span class="tok-kw">fn</span>(val_type) <span class="tok-type">bool</span> = <span class="tok-kw">struct</span>{ <span class="tok-kw">fn</span> <span class="tok-fn">valFn</span>(val: val_type) <span class="tok-type">bool</span> { <span class="tok-kw">return</span> <span class="tok-builtin">@TypeOf</span>(val) == val_type; } }.valFn,</span>
+<span class="line" id="L60">            </span>
+<span class="line" id="L61">        <span class="tok-comment">/// The Name of this Value for user identification and Usage/Help messages.</span></span>
+<span class="line" id="L62">        name: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;&quot;</span>,</span>
+<span class="line" id="L63">        <span class="tok-comment">/// The Description of this Value for Usage/Help messages.</span></span>
+<span class="line" id="L64">        description: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;&quot;</span>,</span>
+<span class="line" id="L65"></span>
+<span class="line" id="L66">        <span class="tok-comment">/// Parse the given Argument to this Value's Type.</span></span>
+<span class="line" id="L67">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">parse</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), arg: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) !val_type {</span>
+<span class="line" id="L68">            _ = self;</span>
+<span class="line" id="L69">            <span class="tok-kw">var</span> san_arg_buf: [<span class="tok-number">100</span>]<span class="tok-type">u8</span> = <span class="tok-null">undefined</span>;</span>
+<span class="line" id="L70">            <span class="tok-kw">const</span> san_arg = toLower(san_arg_buf[<span class="tok-number">0</span>..], arg);</span>
+<span class="line" id="L71">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (<span class="tok-builtin">@typeInfo</span>(val_type)) {</span>
+<span class="line" id="L72">                <span class="tok-comment">//.Null =&gt; error.ValueNotSet,</span>
 </span>
-<span class="line" id="L54">                .Bool =&gt; eql(<span class="tok-type">u8</span>, san_arg, <span class="tok-str">&quot;true&quot;</span>),</span>
-<span class="line" id="L55">                .Pointer =&gt; arg,</span>
-<span class="line" id="L56">                .Int =&gt; parseInt(val_type, arg, <span class="tok-number">0</span>),</span>
-<span class="line" id="L57">                .Float =&gt; parseFloat(val_type, arg),</span>
-<span class="line" id="L58">                <span class="tok-kw">else</span> =&gt; <span class="tok-kw">error</span>.CannotParseArgToValue,</span>
-<span class="line" id="L59">            };</span>
-<span class="line" id="L60">        }</span>
-<span class="line" id="L61"></span>
-<span class="line" id="L62">        <span class="tok-comment">/// Set this Value if the Argument can be Parsed and Validated.</span></span>
-<span class="line" id="L63">        <span class="tok-comment">/// Blank (&quot;&quot;) Arguments will be treated as the current Raw Argument of the Value.</span></span>
-<span class="line" id="L64">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">set</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), arg: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) !<span class="tok-type">void</span> {</span>
-<span class="line" id="L65">            <span class="tok-kw">const</span> set_arg = <span class="tok-kw">if</span>(eql(<span class="tok-type">u8</span>, arg, <span class="tok-str">&quot;&quot;</span>)) self.raw_arg <span class="tok-kw">else</span> arg;</span>
-<span class="line" id="L66">            <span class="tok-kw">const</span> parsed_val = <span class="tok-kw">try</span> self.parse(set_arg);</span>
-<span class="line" id="L67">            <span class="tok-builtin">@constCast</span>(self).is_set =</span>
-<span class="line" id="L68">                <span class="tok-kw">if</span> (self.val_fn != <span class="tok-null">null</span>) self.val_fn.?(parsed_val)</span>
-<span class="line" id="L69">                <span class="tok-kw">else</span> <span class="tok-null">true</span>;</span>
-<span class="line" id="L70">            <span class="tok-kw">if</span> (self.is_set) <span class="tok-builtin">@constCast</span>(self).raw_arg = set_arg</span>
-<span class="line" id="L71">            <span class="tok-kw">else</span> <span class="tok-kw">return</span> <span class="tok-kw">error</span>.InvalidValue;</span>
-<span class="line" id="L72">        }</span>
-<span class="line" id="L73"></span>
-<span class="line" id="L74">        <span class="tok-comment">/// Get the Parsed and Validated Value.</span></span>
-<span class="line" id="L75">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">get</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) !val_type {</span>
-<span class="line" id="L76">            <span class="tok-kw">return</span> </span>
-<span class="line" id="L77">                <span class="tok-kw">if</span> (self.is_set) <span class="tok-kw">try</span> self.parse(self.raw_arg)</span>
-<span class="line" id="L78">                <span class="tok-kw">else</span> <span class="tok-kw">if</span> (val_type == <span class="tok-type">bool</span>) <span class="tok-null">false</span></span>
-<span class="line" id="L79">                <span class="tok-kw">else</span> <span class="tok-kw">if</span> (self.default_val != <span class="tok-null">null</span>) self.default_val.?</span>
-<span class="line" id="L80">                <span class="tok-kw">else</span> <span class="tok-kw">error</span>.ValueNotSet;</span>
-<span class="line" id="L81">        }</span>
-<span class="line" id="L82"></span>
-<span class="line" id="L83">        <span class="tok-comment">/// Get the Value Type</span></span>
-<span class="line" id="L84">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">getType</span>() <span class="tok-type">type</span> { <span class="tok-kw">return</span> val_type; }</span>
-<span class="line" id="L85">    };</span>
-<span class="line" id="L86">}</span>
-<span class="line" id="L87"></span>
-<span class="line" id="L88"><span class="tok-comment">/// Generic Value to handle a Value regardless of its inner type.</span></span>
-<span class="line" id="L89"><span class="tok-kw">pub</span> <span class="tok-kw">const</span> Generic = genUnion: {</span>
-<span class="line" id="L90">    <span class="tok-kw">var</span> gen_union = <span class="tok-kw">union</span>(<span class="tok-kw">enum</span>){</span>
-<span class="line" id="L91">        <span class="tok-type">bool</span>: Typed(<span class="tok-type">bool</span>),</span>
-<span class="line" id="L92">        </span>
-<span class="line" id="L93">        string: Typed([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>),</span>
-<span class="line" id="L94">        </span>
-<span class="line" id="L95">        <span class="tok-type">u4</span>: Typed(<span class="tok-type">u4</span>),</span>
-<span class="line" id="L96">        <span class="tok-type">u8</span>: Typed(<span class="tok-type">u8</span>),</span>
-<span class="line" id="L97">        <span class="tok-type">u16</span>: Typed(<span class="tok-type">u16</span>),</span>
-<span class="line" id="L98">        <span class="tok-type">u32</span>: Typed(<span class="tok-type">u32</span>),</span>
-<span class="line" id="L99">        <span class="tok-type">u64</span>: Typed(<span class="tok-type">u64</span>),</span>
-<span class="line" id="L100">        <span class="tok-type">u128</span>: Typed(<span class="tok-type">u128</span>),</span>
-<span class="line" id="L101">        <span class="tok-type">u256</span>: Typed(<span class="tok-type">u256</span>),</span>
+<span class="line" id="L73">                .Bool =&gt; eql(<span class="tok-type">u8</span>, san_arg, <span class="tok-str">&quot;true&quot;</span>),</span>
+<span class="line" id="L74">                .Pointer =&gt; arg,</span>
+<span class="line" id="L75">                .Int =&gt; parseInt(val_type, arg, <span class="tok-number">0</span>),</span>
+<span class="line" id="L76">                .Float =&gt; parseFloat(val_type, arg),</span>
+<span class="line" id="L77">                <span class="tok-kw">else</span> =&gt; <span class="tok-kw">error</span>.CannotParseArgToValue,</span>
+<span class="line" id="L78">            };</span>
+<span class="line" id="L79">        }</span>
+<span class="line" id="L80"></span>
+<span class="line" id="L81">        <span class="tok-comment">/// Set this Value if the Argument can be Parsed and Validated.</span></span>
+<span class="line" id="L82">        <span class="tok-comment">/// Blank (&quot;&quot;) Arguments will be treated as the current Raw Argument of the Value.</span></span>
+<span class="line" id="L83">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">set</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), set_arg: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) !<span class="tok-type">void</span> {</span>
+<span class="line" id="L84">            <span class="tok-kw">const</span> parsed_arg = <span class="tok-kw">try</span> self.parse(set_arg);</span>
+<span class="line" id="L85">            <span class="tok-builtin">@constCast</span>(self).is_set =</span>
+<span class="line" id="L86">                <span class="tok-kw">if</span> (self.val_fn != <span class="tok-null">null</span>) self.val_fn.?(parsed_arg)</span>
+<span class="line" id="L87">                <span class="tok-kw">else</span> <span class="tok-null">true</span>;</span>
+<span class="line" id="L88">            <span class="tok-kw">if</span> (self.is_set) {</span>
+<span class="line" id="L89">                <span class="tok-kw">switch</span> (self.set_behavior) {</span>
+<span class="line" id="L90">                    .First =&gt; <span class="tok-kw">if</span> (self._set_args[<span class="tok-number">0</span>] == <span class="tok-null">null</span>) { </span>
+<span class="line" id="L91">                        <span class="tok-builtin">@constCast</span>(self)._set_args[<span class="tok-number">0</span>] = parsed_arg;</span>
+<span class="line" id="L92">                    },</span>
+<span class="line" id="L93">                    .Last =&gt; <span class="tok-builtin">@constCast</span>(self)._set_args[<span class="tok-number">0</span>] = parsed_arg,</span>
+<span class="line" id="L94">                    .Multi =&gt; <span class="tok-kw">if</span> (self._arg_idx &lt; self.max_args) {</span>
+<span class="line" id="L95">                        <span class="tok-builtin">@constCast</span>(self)._set_args[self._arg_idx] = parsed_arg;</span>
+<span class="line" id="L96">                        <span class="tok-builtin">@constCast</span>(self)._arg_idx += <span class="tok-number">1</span>;</span>
+<span class="line" id="L97">                    }</span>
+<span class="line" id="L98">                }</span>
+<span class="line" id="L99">            }</span>
+<span class="line" id="L100">            <span class="tok-kw">else</span> <span class="tok-kw">return</span> <span class="tok-kw">error</span>.InvalidValue;</span>
+<span class="line" id="L101">        }</span>
 <span class="line" id="L102"></span>
-<span class="line" id="L103">        <span class="tok-type">i4</span>: Typed(<span class="tok-type">i4</span>),</span>
-<span class="line" id="L104">        <span class="tok-type">i8</span>: Typed(<span class="tok-type">i8</span>),</span>
-<span class="line" id="L105">        <span class="tok-type">i16</span>: Typed(<span class="tok-type">i16</span>),</span>
-<span class="line" id="L106">        <span class="tok-type">i32</span>: Typed(<span class="tok-type">i32</span>),</span>
-<span class="line" id="L107">        <span class="tok-type">i64</span>: Typed(<span class="tok-type">i64</span>),</span>
-<span class="line" id="L108">        <span class="tok-type">i128</span>: Typed(<span class="tok-type">i128</span>),</span>
-<span class="line" id="L109">        <span class="tok-type">i256</span>: Typed(<span class="tok-type">i256</span>),</span>
-<span class="line" id="L110"></span>
-<span class="line" id="L111">        <span class="tok-type">f16</span>: Typed(<span class="tok-type">f16</span>),</span>
-<span class="line" id="L112">        <span class="tok-type">f32</span>: Typed(<span class="tok-type">f32</span>),</span>
-<span class="line" id="L113">        <span class="tok-type">f64</span>: Typed(<span class="tok-type">f64</span>),</span>
-<span class="line" id="L114">        <span class="tok-type">f128</span>: Typed(<span class="tok-type">f128</span>),</span>
-<span class="line" id="L115"></span>
-<span class="line" id="L116">        <span class="tok-comment">/// Get the Parsed and Validated Value of the inner Typed Value.</span></span>
-<span class="line" id="L117">        <span class="tok-comment">/// Comptime Only (TODO: See if this can be made Runtime)</span></span>
-<span class="line" id="L118">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">get</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) !<span class="tok-kw">switch</span> (meta.activeTag(self.*)) { <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@TypeOf</span>(<span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag))).getType(), } {</span>
-<span class="line" id="L119">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
-<span class="line" id="L120">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-kw">try</span> <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).get(),</span>
-<span class="line" id="L121">            };</span>
-<span class="line" id="L122">        }</span>
-<span class="line" id="L123">        <span class="tok-comment">/// Set the inner Typed Value if the provided Argument can be Parsed and Validated.</span></span>
-<span class="line" id="L124">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">set</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), arg: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) !<span class="tok-type">void</span> { </span>
-<span class="line" id="L125">            <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
-<span class="line" id="L126">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-kw">try</span> <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).set(arg),</span>
-<span class="line" id="L127">            }</span>
-<span class="line" id="L128">        }</span>
-<span class="line" id="L129"></span>
-<span class="line" id="L130">        <span class="tok-comment">/// Get the inner Typed Value's name.</span></span>
-<span class="line" id="L131">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">name</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) []<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
-<span class="line" id="L132">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
-<span class="line" id="L133">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).name,</span>
-<span class="line" id="L134">            };</span>
-<span class="line" id="L135">        }</span>
-<span class="line" id="L136">        <span class="tok-comment">/// Get the inner Typed Value's type.</span></span>
-<span class="line" id="L137">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">valType</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) []<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
-<span class="line" id="L138">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
-<span class="line" id="L139">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@typeName</span>(<span class="tok-builtin">@TypeOf</span>(<span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag))).getType()),</span>
-<span class="line" id="L140">            };</span>
-<span class="line" id="L141">        }</span>
-<span class="line" id="L142">        <span class="tok-comment">/// Get the inner Typed Value's description.</span></span>
-<span class="line" id="L143">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">description</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) []<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
-<span class="line" id="L144">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
-<span class="line" id="L145">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).description,</span>
-<span class="line" id="L146">            };</span>
-<span class="line" id="L147">        }</span>
-<span class="line" id="L148">    };</span>
-<span class="line" id="L149"></span>
-<span class="line" id="L150">    <span class="tok-comment">// TODO: See if there's another way to add these fields procedurally to avoid the declaration reification issue with @Type(builtin.Type{})</span>
+<span class="line" id="L103">        <span class="tok-comment">/// Get the first Parsed and Validated Argument of this Value.</span></span>
+<span class="line" id="L104">        <span class="tok-comment">/// This will pull the first value from `_set_args` and should be used with the `First` or `Last` Set Behaviors.</span></span>
+<span class="line" id="L105">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">get</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) !val_type {</span>
+<span class="line" id="L106">            <span class="tok-kw">return</span> </span>
+<span class="line" id="L107">                <span class="tok-kw">if</span> (self.is_set) self._set_args[<span class="tok-number">0</span>].?</span>
+<span class="line" id="L108">                <span class="tok-kw">else</span> <span class="tok-kw">if</span> (val_type == <span class="tok-type">bool</span>) <span class="tok-null">false</span></span>
+<span class="line" id="L109">                <span class="tok-kw">else</span> <span class="tok-kw">if</span> (self.default_val != <span class="tok-null">null</span>) self.default_val.?</span>
+<span class="line" id="L110">                <span class="tok-kw">else</span> <span class="tok-kw">error</span>.ValueNotSet;</span>
+<span class="line" id="L111">        }</span>
+<span class="line" id="L112"></span>
+<span class="line" id="L113">        <span class="tok-comment">/// Get All Parsed and Validated Arguments of this Value.</span></span>
+<span class="line" id="L114">        <span class="tok-comment">/// This will pull All values from `_set_args` and should be used with `Multi` Set Behavior.</span></span>
+<span class="line" id="L115">        <span class="tok-comment">/// TODO: Make this more efficient.</span></span>
+<span class="line" id="L116">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">getAll</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), alloc: mem.Allocator) ![]val_type {</span>
+<span class="line" id="L117">            <span class="tok-kw">if</span> (!self.is_set) <span class="tok-kw">return</span> <span class="tok-kw">error</span>.ValueNotSet;</span>
+<span class="line" id="L118">            <span class="tok-kw">var</span> vals = <span class="tok-kw">try</span> alloc.alloc(val_type, self._arg_idx);</span>
+<span class="line" id="L119">            <span class="tok-kw">for</span> (self._set_args[<span class="tok-number">0</span>..self._arg_idx], <span class="tok-number">0</span>..) |arg, idx| vals[idx] = arg.?;</span>
+<span class="line" id="L120">            <span class="tok-kw">return</span> vals;</span>
+<span class="line" id="L121">        }</span>
+<span class="line" id="L122"></span>
+<span class="line" id="L123">        <span class="tok-comment">/// Get the Value Type</span></span>
+<span class="line" id="L124">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">getType</span>() <span class="tok-type">type</span> { <span class="tok-kw">return</span> val_type; }</span>
+<span class="line" id="L125">    };</span>
+<span class="line" id="L126">}</span>
+<span class="line" id="L127"></span>
+<span class="line" id="L128"><span class="tok-comment">/// Generic Value to handle a Value regardless of its inner type.</span></span>
+<span class="line" id="L129"><span class="tok-kw">pub</span> <span class="tok-kw">const</span> Generic = genUnion: {</span>
+<span class="line" id="L130">    <span class="tok-kw">var</span> gen_union = <span class="tok-kw">union</span>(<span class="tok-kw">enum</span>){</span>
+<span class="line" id="L131">        <span class="tok-type">bool</span>: Typed(<span class="tok-type">bool</span>),</span>
+<span class="line" id="L132">        </span>
+<span class="line" id="L133">        string: Typed([]<span class="tok-kw">const</span> <span class="tok-type">u8</span>),</span>
+<span class="line" id="L134">        </span>
+<span class="line" id="L135">        <span class="tok-type">u4</span>: Typed(<span class="tok-type">u4</span>),</span>
+<span class="line" id="L136">        <span class="tok-type">u8</span>: Typed(<span class="tok-type">u8</span>),</span>
+<span class="line" id="L137">        <span class="tok-type">u16</span>: Typed(<span class="tok-type">u16</span>),</span>
+<span class="line" id="L138">        <span class="tok-type">u32</span>: Typed(<span class="tok-type">u32</span>),</span>
+<span class="line" id="L139">        <span class="tok-type">u64</span>: Typed(<span class="tok-type">u64</span>),</span>
+<span class="line" id="L140">        <span class="tok-type">u128</span>: Typed(<span class="tok-type">u128</span>),</span>
+<span class="line" id="L141">        <span class="tok-type">u256</span>: Typed(<span class="tok-type">u256</span>),</span>
+<span class="line" id="L142"></span>
+<span class="line" id="L143">        <span class="tok-type">i4</span>: Typed(<span class="tok-type">i4</span>),</span>
+<span class="line" id="L144">        <span class="tok-type">i8</span>: Typed(<span class="tok-type">i8</span>),</span>
+<span class="line" id="L145">        <span class="tok-type">i16</span>: Typed(<span class="tok-type">i16</span>),</span>
+<span class="line" id="L146">        <span class="tok-type">i32</span>: Typed(<span class="tok-type">i32</span>),</span>
+<span class="line" id="L147">        <span class="tok-type">i64</span>: Typed(<span class="tok-type">i64</span>),</span>
+<span class="line" id="L148">        <span class="tok-type">i128</span>: Typed(<span class="tok-type">i128</span>),</span>
+<span class="line" id="L149">        <span class="tok-type">i256</span>: Typed(<span class="tok-type">i256</span>),</span>
+<span class="line" id="L150"></span>
+<span class="line" id="L151">        <span class="tok-type">f16</span>: Typed(<span class="tok-type">f16</span>),</span>
+<span class="line" id="L152">        <span class="tok-type">f32</span>: Typed(<span class="tok-type">f32</span>),</span>
+<span class="line" id="L153">        <span class="tok-type">f64</span>: Typed(<span class="tok-type">f64</span>),</span>
+<span class="line" id="L154">        <span class="tok-type">f128</span>: Typed(<span class="tok-type">f128</span>),</span>
+<span class="line" id="L155"></span>
+<span class="line" id="L156">        <span class="tok-comment">/// Get the Parsed and Validated Value of the inner Typed Value.</span></span>
+<span class="line" id="L157">        <span class="tok-comment">/// Comptime Only (TODO: See if this can be made Runtime)</span></span>
+<span class="line" id="L158">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">get</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) !<span class="tok-kw">switch</span> (meta.activeTag(self.*)) { <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@TypeOf</span>(<span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag))).getType(), } {</span>
+<span class="line" id="L159">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
+<span class="line" id="L160">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-kw">try</span> <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).get(),</span>
+<span class="line" id="L161">            };</span>
+<span class="line" id="L162">        }</span>
+<span class="line" id="L163">        <span class="tok-comment">/// Set the inner Typed Value if the provided Argument can be Parsed and Validated.</span></span>
+<span class="line" id="L164">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">set</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>(), arg: []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) !<span class="tok-type">void</span> { </span>
+<span class="line" id="L165">            <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
+<span class="line" id="L166">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-kw">try</span> <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).set(arg),</span>
+<span class="line" id="L167">            }</span>
+<span class="line" id="L168">        }</span>
+<span class="line" id="L169"></span>
+<span class="line" id="L170">        <span class="tok-comment">/// Get the inner Typed Value's Name.</span></span>
+<span class="line" id="L171">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">name</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) []<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
+<span class="line" id="L172">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
+<span class="line" id="L173">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).name,</span>
+<span class="line" id="L174">            };</span>
+<span class="line" id="L175">        }</span>
+<span class="line" id="L176">        <span class="tok-comment">/// Get the inner Typed Value's Type.</span></span>
+<span class="line" id="L177">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">valType</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) []<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
+<span class="line" id="L178">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
+<span class="line" id="L179">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@typeName</span>(<span class="tok-builtin">@TypeOf</span>(<span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag))).getType()),</span>
+<span class="line" id="L180">            };</span>
+<span class="line" id="L181">        }</span>
+<span class="line" id="L182">        <span class="tok-comment">/// Get the inner Typed Value's Description.</span></span>
+<span class="line" id="L183">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">description</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) []<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
+<span class="line" id="L184">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
+<span class="line" id="L185">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).description,</span>
+<span class="line" id="L186">            };</span>
+<span class="line" id="L187">        }</span>
+<span class="line" id="L188">        <span class="tok-comment">/// Check the inner Typed Value's is Set.</span></span>
+<span class="line" id="L189">        <span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">isSet</span>(self: *<span class="tok-kw">const</span> <span class="tok-builtin">@This</span>()) <span class="tok-type">bool</span> {</span>
+<span class="line" id="L190">            <span class="tok-kw">return</span> <span class="tok-kw">switch</span> (meta.activeTag(self.*)) {</span>
+<span class="line" id="L191">                <span class="tok-kw">inline</span> <span class="tok-kw">else</span> =&gt; |tag| <span class="tok-builtin">@field</span>(self, <span class="tok-builtin">@tagName</span>(tag)).is_set,</span>
+<span class="line" id="L192">            };</span>
+<span class="line" id="L193">        }</span>
+<span class="line" id="L194">    };</span>
+<span class="line" id="L195"></span>
+<span class="line" id="L196">    <span class="tok-comment">// TODO: See if there's another way to add these fields procedurally to avoid the declaration reification issue with @Type(builtin.Type{})</span>
 </span>
-<span class="line" id="L151">    <span class="tok-comment">//var fields: []const UnionField = meta.fields(gen_union);</span>
+<span class="line" id="L197">    <span class="tok-comment">//var fields: []const UnionField = meta.fields(gen_union);</span>
 </span>
-<span class="line" id="L152">    <span class="tok-comment">//@setEvalBranchQuota(2000);</span>
+<span class="line" id="L198">    <span class="tok-comment">//@setEvalBranchQuota(2000);</span>
 </span>
-<span class="line" id="L153">    <span class="tok-comment">//inline for (1..255) |bit_width| {</span>
+<span class="line" id="L199">    <span class="tok-comment">//inline for (1..255) |bit_width| {</span>
 </span>
-<span class="line" id="L154">    <span class="tok-comment">//    fields = fields ++ .{ UnionField {</span>
+<span class="line" id="L200">    <span class="tok-comment">//    fields = fields ++ .{ UnionField {</span>
 </span>
-<span class="line" id="L155">    <span class="tok-comment">//       .name = @typeName(meta.Int(.unsigned, bit_width)),</span>
+<span class="line" id="L201">    <span class="tok-comment">//       .name = @typeName(meta.Int(.unsigned, bit_width)),</span>
 </span>
-<span class="line" id="L156">    <span class="tok-comment">//       .type = meta.Int(.unsigned, bit_width),</span>
+<span class="line" id="L202">    <span class="tok-comment">//       .type = meta.Int(.unsigned, bit_width),</span>
 </span>
-<span class="line" id="L157">    <span class="tok-comment">//       .alignment = @alignOf(meta.Int(.unsigned, bit_width)),</span>
+<span class="line" id="L203">    <span class="tok-comment">//       .alignment = @alignOf(meta.Int(.unsigned, bit_width)),</span>
 </span>
-<span class="line" id="L158">    <span class="tok-comment">//    } };</span>
+<span class="line" id="L204">    <span class="tok-comment">//    } };</span>
 </span>
-<span class="line" id="L159">    <span class="tok-comment">//    fields = fields ++ .{ UnionField {</span>
+<span class="line" id="L205">    <span class="tok-comment">//    fields = fields ++ .{ UnionField {</span>
 </span>
-<span class="line" id="L160">    <span class="tok-comment">//       .name = @typeName(meta.Int(.signed, bit_width)),</span>
+<span class="line" id="L206">    <span class="tok-comment">//       .name = @typeName(meta.Int(.signed, bit_width)),</span>
 </span>
-<span class="line" id="L161">    <span class="tok-comment">//       .type = meta.Int(.signed, bit_width),</span>
+<span class="line" id="L207">    <span class="tok-comment">//       .type = meta.Int(.signed, bit_width),</span>
 </span>
-<span class="line" id="L162">    <span class="tok-comment">//       .alignment = @alignOf(meta.Int(.signed, bit_width)),</span>
+<span class="line" id="L208">    <span class="tok-comment">//       .alignment = @alignOf(meta.Int(.signed, bit_width)),</span>
 </span>
-<span class="line" id="L163">    <span class="tok-comment">//    } };</span>
+<span class="line" id="L209">    <span class="tok-comment">//    } };</span>
 </span>
-<span class="line" id="L164">    <span class="tok-comment">//}</span>
+<span class="line" id="L210">    <span class="tok-comment">//}</span>
 </span>
-<span class="line" id="L165"></span>
-<span class="line" id="L166">    <span class="tok-kw">break</span> :genUnion gen_union;</span>
-<span class="line" id="L167">};</span>
-<span class="line" id="L168"></span>
-<span class="line" id="L169"><span class="tok-comment">/// Initialize a Generic Value with a specific Type.</span></span>
-<span class="line" id="L170"><span class="tok-comment">/// TODO: Coerce Typed([]u8) to Typed([]const u8) </span></span>
-<span class="line" id="L171"><span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">init</span>(<span class="tok-kw">comptime</span> T: <span class="tok-type">type</span>, <span class="tok-kw">comptime</span> typed_val: Typed(T)) Generic {</span>
-<span class="line" id="L172">    <span class="tok-kw">const</span> active_tag = <span class="tok-kw">if</span> (T == []<span class="tok-kw">const</span> <span class="tok-type">u8</span> <span class="tok-kw">or</span> T == []<span class="tok-type">u8</span>) <span class="tok-str">&quot;string&quot;</span> <span class="tok-kw">else</span> <span class="tok-builtin">@typeName</span>(T);</span>
-<span class="line" id="L173">    <span class="tok-kw">return</span> <span class="tok-builtin">@unionInit</span>(Generic, active_tag, typed_val);</span>
-<span class="line" id="L174">}</span>
-<span class="line" id="L175"></span>
-<span class="line" id="L176"></span>
+<span class="line" id="L211"></span>
+<span class="line" id="L212">    <span class="tok-kw">break</span> :genUnion gen_union;</span>
+<span class="line" id="L213">};</span>
+<span class="line" id="L214"></span>
+<span class="line" id="L215"><span class="tok-comment">/// Create a Generic Value with a specific Type.</span></span>
+<span class="line" id="L216"><span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">ofType</span>(<span class="tok-kw">comptime</span> T: <span class="tok-type">type</span>, <span class="tok-kw">comptime</span> typed_val: Typed(T)) Generic {</span>
+<span class="line" id="L217">    <span class="tok-kw">const</span> active_tag = <span class="tok-kw">if</span> (T == []<span class="tok-kw">const</span> <span class="tok-type">u8</span>) <span class="tok-str">&quot;string&quot;</span> <span class="tok-kw">else</span> <span class="tok-builtin">@typeName</span>(T);</span>
+<span class="line" id="L218">    <span class="tok-kw">return</span> <span class="tok-builtin">@unionInit</span>(Generic, active_tag, typed_val);</span>
+<span class="line" id="L219">}</span>
+<span class="line" id="L220"></span>
 </code></pre></body>
 </html>

--- a/docs/src/cova/cova.zig.html
+++ b/docs/src/cova/cova.zig.html
@@ -130,242 +130,293 @@
 <span class="line" id="L15"><span class="tok-kw">pub</span> <span class="tok-kw">const</span> Option = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;Option.zig&quot;</span>);</span>
 <span class="line" id="L16"><span class="tok-kw">pub</span> <span class="tok-kw">const</span> Value = <span class="tok-builtin">@import</span>(<span class="tok-str">&quot;Value.zig&quot;</span>);</span>
 <span class="line" id="L17"></span>
-<span class="line" id="L18"><span class="tok-comment">/// Parse provided Argument tokens into Commands, Options, and Values.</span></span>
-<span class="line" id="L19"><span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">parseArgs</span>(args: *<span class="tok-kw">const</span> proc.ArgIterator, <span class="tok-kw">comptime</span> CustomCommand: <span class="tok-type">type</span>, cmd: *<span class="tok-kw">const</span> CustomCommand, writer: <span class="tok-kw">anytype</span>) !<span class="tok-type">void</span> {</span>
-<span class="line" id="L20">    <span class="tok-kw">var</span> val_idx: <span class="tok-type">u8</span> = <span class="tok-number">0</span>;</span>
-<span class="line" id="L21"></span>
-<span class="line" id="L22">    <span class="tok-kw">const</span> optType = <span class="tok-builtin">@TypeOf</span>(cmd.*).CustomOption;</span>
-<span class="line" id="L23"></span>
-<span class="line" id="L24">    <span class="tok-comment">// Bypass argument 0 (the filename being executed);</span>
+<span class="line" id="L18"><span class="tok-kw">pub</span> <span class="tok-kw">const</span> ParseConfig = <span class="tok-kw">struct</span> {</span>
+<span class="line" id="L19">    <span class="tok-comment">/// Mandate that all Values must be filled, otherwise error out.</span></span>
+<span class="line" id="L20">    <span class="tok-comment">/// This should generally be set to `true`. Prefer to use Options over Values for Arguments that are not mandatory.</span></span>
+<span class="line" id="L21">    vals_mandatory: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L22">    <span class="tok-comment">/// Skip the first Argument (the executable's name).</span></span>
+<span class="line" id="L23">    <span class="tok-comment">/// This should generally be set to `true`, but the option is here for unforeseen outliers.</span></span>
+<span class="line" id="L24">    skip_exe_name_arg: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L25">    <span class="tok-comment">/// Allow there to be no space ' ' between Options and Values.</span></span>
+<span class="line" id="L26">    <span class="tok-comment">/// This is allowed per the POSIX standard, but may not be ideal as it interrupts the parsing of chained booleans even in the event of a misstype.</span></span>
+<span class="line" id="L27">    allow_opt_val_no_space: <span class="tok-type">bool</span> = <span class="tok-null">true</span>,</span>
+<span class="line" id="L28">    <span class="tok-comment">/// Specify custom Separators between Options and their Values.</span></span>
+<span class="line" id="L29">    <span class="tok-comment">/// Spaces ' ' are implicitly included.</span></span>
+<span class="line" id="L30">    opt_val_seps: []<span class="tok-kw">const</span> <span class="tok-type">u8</span> = <span class="tok-str">&quot;=&quot;</span>,</span>
+<span class="line" id="L31">};</span>
+<span class="line" id="L32"></span>
+<span class="line" id="L33"><span class="tok-comment">/// Parse provided Argument tokens into Commands, Options, and Values.</span></span>
+<span class="line" id="L34"><span class="tok-kw">pub</span> <span class="tok-kw">fn</span> <span class="tok-fn">parseArgs</span>(</span>
+<span class="line" id="L35">    args: *<span class="tok-kw">const</span> proc.ArgIterator, </span>
+<span class="line" id="L36">    <span class="tok-kw">comptime</span> CustomCommand: <span class="tok-type">type</span>, </span>
+<span class="line" id="L37">    cmd: *<span class="tok-kw">const</span> CustomCommand, </span>
+<span class="line" id="L38">    writer: <span class="tok-kw">anytype</span>,</span>
+<span class="line" id="L39">    parse_config: ParseConfig,</span>
+<span class="line" id="L40">) !<span class="tok-type">void</span> {</span>
+<span class="line" id="L41">    <span class="tok-kw">var</span> val_idx: <span class="tok-type">u8</span> = <span class="tok-number">0</span>;</span>
+<span class="line" id="L42"></span>
+<span class="line" id="L43">    <span class="tok-kw">const</span> optType = <span class="tok-builtin">@TypeOf</span>(cmd.*).CustomOption;</span>
+<span class="line" id="L44"></span>
+<span class="line" id="L45">    <span class="tok-comment">// Bypass argument 0 (the filename being executed);</span>
 </span>
-<span class="line" id="L25">    <span class="tok-kw">const</span> init_arg = <span class="tok-kw">if</span> (<span class="tok-builtin">@constCast</span>(args).inner.index == <span class="tok-number">0</span>) <span class="tok-builtin">@constCast</span>(args).next()</span>
-<span class="line" id="L26">                     <span class="tok-kw">else</span> argsPeak(args); </span>
-<span class="line" id="L27">    log.debug(<span class="tok-str">&quot;Parsing Command '{s}'...&quot;</span>, .{ cmd.name });</span>
-<span class="line" id="L28">    log.debug(<span class="tok-str">&quot;Initial Arg: {?s}&quot;</span>, .{ init_arg <span class="tok-kw">orelse</span> <span class="tok-str">&quot;END OF ARGS!&quot;</span> });</span>
-<span class="line" id="L29">    <span class="tok-kw">defer</span> log.debug(<span class="tok-str">&quot;Finished Parsing '{s}'.&quot;</span>, .{ cmd.name });</span>
-<span class="line" id="L30"></span>
-<span class="line" id="L31">    parseArg: <span class="tok-kw">while</span> (<span class="tok-builtin">@constCast</span>(args).next()) |arg| {</span>
-<span class="line" id="L32">        <span class="tok-kw">if</span> (init_arg == <span class="tok-null">null</span>) <span class="tok-kw">return</span>;</span>
-<span class="line" id="L33">        <span class="tok-kw">var</span> unmatched = <span class="tok-null">false</span>;</span>
-<span class="line" id="L34">        <span class="tok-comment">// Check for a Sub Command first...</span>
+<span class="line" id="L46">    <span class="tok-kw">const</span> init_arg = </span>
+<span class="line" id="L47">        <span class="tok-kw">if</span> (parse_config.skip_exe_name_arg <span class="tok-kw">and</span> <span class="tok-builtin">@constCast</span>(args).inner.index == <span class="tok-number">0</span>) <span class="tok-builtin">@constCast</span>(args).next()</span>
+<span class="line" id="L48">        <span class="tok-kw">else</span> argsPeak(args); </span>
+<span class="line" id="L49">    log.debug(<span class="tok-str">&quot;Parsing Command '{s}'...&quot;</span>, .{ cmd.name });</span>
+<span class="line" id="L50">    log.debug(<span class="tok-str">&quot;Initial Arg: {?s}&quot;</span>, .{ init_arg <span class="tok-kw">orelse</span> <span class="tok-str">&quot;END OF ARGS!&quot;</span> });</span>
+<span class="line" id="L51">    <span class="tok-kw">defer</span> log.debug(<span class="tok-str">&quot;Finished Parsing '{s}'.&quot;</span>, .{ cmd.name });</span>
+<span class="line" id="L52"></span>
+<span class="line" id="L53">    parseArg: <span class="tok-kw">while</span> (<span class="tok-builtin">@constCast</span>(args).next()) |arg| {</span>
+<span class="line" id="L54">        <span class="tok-kw">if</span> (init_arg == <span class="tok-null">null</span>) <span class="tok-kw">break</span> :parseArg;</span>
+<span class="line" id="L55">        <span class="tok-kw">var</span> unmatched = <span class="tok-null">false</span>;</span>
+<span class="line" id="L56">        <span class="tok-comment">// Check for a Sub Command first...</span>
 </span>
-<span class="line" id="L35">        <span class="tok-kw">if</span> (cmd.sub_cmds != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L36">            log.debug(<span class="tok-str">&quot;Attempting to Parse Commands...&quot;</span>, .{});</span>
-<span class="line" id="L37">            <span class="tok-kw">for</span> (cmd.sub_cmds.?) |sub_cmd| {</span>
-<span class="line" id="L38">                <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, sub_cmd.name, arg)) {</span>
-<span class="line" id="L39">                    parseArgs(args, CustomCommand, sub_cmd, writer) <span class="tok-kw">catch</span> { </span>
-<span class="line" id="L40">                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Command '{s}'.\n&quot;</span>, .{ sub_cmd.name });</span>
-<span class="line" id="L41">                        <span class="tok-kw">try</span> sub_cmd.usage(writer);</span>
-<span class="line" id="L42">                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L43">                        <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseCommand;</span>
-<span class="line" id="L44">                    };</span>
-<span class="line" id="L45">                    log.debug(<span class="tok-str">&quot;Parsed Command '{s}'.&quot;</span>, .{ sub_cmd.name });</span>
-<span class="line" id="L46">                    cmd.setSubCmd(sub_cmd); </span>
-<span class="line" id="L47">                    <span class="tok-kw">continue</span> :parseArg;</span>
-<span class="line" id="L48">                }</span>
-<span class="line" id="L49">            }</span>
-<span class="line" id="L50">            unmatched = <span class="tok-null">true</span>;</span>
-<span class="line" id="L51">            log.debug(<span class="tok-str">&quot;No Commands Matched for Command '{s}'.&quot;</span>, .{ cmd.name });</span>
-<span class="line" id="L52">        }</span>
-<span class="line" id="L53">        <span class="tok-comment">// ...Then for any Options...</span>
+<span class="line" id="L57">        <span class="tok-kw">if</span> (cmd.sub_cmds != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L58">            log.debug(<span class="tok-str">&quot;Attempting to Parse Commands...&quot;</span>, .{});</span>
+<span class="line" id="L59">            <span class="tok-kw">for</span> (cmd.sub_cmds.?) |sub_cmd| {</span>
+<span class="line" id="L60">                <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, sub_cmd.name, arg)) {</span>
+<span class="line" id="L61">                    parseArgs(args, CustomCommand, sub_cmd, writer, parse_config) <span class="tok-kw">catch</span> { </span>
+<span class="line" id="L62">                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Command '{s}'.\n&quot;</span>, .{ sub_cmd.name });</span>
+<span class="line" id="L63">                        <span class="tok-kw">try</span> sub_cmd.usage(writer);</span>
+<span class="line" id="L64">                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L65">                        <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseCommand;</span>
+<span class="line" id="L66">                    };</span>
+<span class="line" id="L67">                    log.debug(<span class="tok-str">&quot;Parsed Command '{s}'.&quot;</span>, .{ sub_cmd.name });</span>
+<span class="line" id="L68">                    cmd.setSubCmd(sub_cmd); </span>
+<span class="line" id="L69">                    <span class="tok-kw">continue</span> :parseArg;</span>
+<span class="line" id="L70">                }</span>
+<span class="line" id="L71">            }</span>
+<span class="line" id="L72">            unmatched = <span class="tok-null">true</span>;</span>
+<span class="line" id="L73">            log.debug(<span class="tok-str">&quot;No Commands Matched for Command '{s}'.&quot;</span>, .{ cmd.name });</span>
+<span class="line" id="L74">        }</span>
+<span class="line" id="L75">        <span class="tok-comment">// ...Then for any Options...</span>
 </span>
-<span class="line" id="L54">        <span class="tok-kw">if</span> (cmd.opts != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L55">            log.debug(<span class="tok-str">&quot;Attempting to Parse Options...&quot;</span>, .{});</span>
-<span class="line" id="L56">            <span class="tok-kw">const</span> short_pf = optType.short_prefix;</span>
-<span class="line" id="L57">            <span class="tok-kw">const</span> long_pf = optType.long_prefix;</span>
-<span class="line" id="L58">            <span class="tok-comment">// - Short Options</span>
+<span class="line" id="L76">        <span class="tok-kw">if</span> (cmd.opts != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L77">            log.debug(<span class="tok-str">&quot;Attempting to Parse Options...&quot;</span>, .{});</span>
+<span class="line" id="L78">            <span class="tok-kw">const</span> short_pf = optType.short_prefix;</span>
+<span class="line" id="L79">            <span class="tok-kw">const</span> long_pf = optType.long_prefix;</span>
+<span class="line" id="L80">            <span class="tok-comment">// - Short Options</span>
 </span>
-<span class="line" id="L59">            <span class="tok-kw">if</span> (arg[<span class="tok-number">0</span>] == short_pf <span class="tok-kw">and</span> arg[<span class="tok-number">1</span>] != short_pf) {</span>
-<span class="line" id="L60">                <span class="tok-kw">const</span> short_opts = arg[<span class="tok-number">1</span>..];</span>
-<span class="line" id="L61">                shortOpts: <span class="tok-kw">for</span> (short_opts, <span class="tok-number">0</span>..) |short_opt, short_idx| {</span>
-<span class="line" id="L62">                    <span class="tok-kw">for</span> (cmd.opts.?) |opt| {</span>
-<span class="line" id="L63">                        <span class="tok-kw">if</span> (opt.short_name != <span class="tok-null">null</span> <span class="tok-kw">and</span> short_opt == opt.short_name.?) {</span>
-<span class="line" id="L64">                            <span class="tok-comment">//TODO: Figure out why these if statements need a &quot;try&quot;. Possibly due to subtraction underflow?</span>
+<span class="line" id="L81">            <span class="tok-kw">if</span> (arg[<span class="tok-number">0</span>] == short_pf <span class="tok-kw">and</span> arg[<span class="tok-number">1</span>] != short_pf) {</span>
+<span class="line" id="L82">                <span class="tok-kw">const</span> short_opts = arg[<span class="tok-number">1</span>..];</span>
+<span class="line" id="L83">                shortOpts: <span class="tok-kw">for</span> (short_opts, <span class="tok-number">0</span>..) |short_opt, short_idx| {</span>
+<span class="line" id="L84">                    <span class="tok-kw">for</span> (cmd.opts.?) |opt| {</span>
+<span class="line" id="L85">                        <span class="tok-kw">if</span> (opt.short_name != <span class="tok-null">null</span> <span class="tok-kw">and</span> short_opt == opt.short_name.?) {</span>
+<span class="line" id="L86">                            <span class="tok-comment">// Handle Argument provided to this Option with '=' instead of ' '.</span>
 </span>
-<span class="line" id="L65">                            <span class="tok-comment">// Handle Argument provided to this Option with '=' instead of ' '.</span>
+<span class="line" id="L87">                            <span class="tok-kw">if</span> (mem.indexOfScalar(<span class="tok-type">u8</span>, parse_config.opt_val_seps, short_opts[short_idx + <span class="tok-number">1</span>]) != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L88">                                <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) {</span>
+<span class="line" id="L89">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;The Option '{c}{?c}: {s}' is a Boolean/Toggle and cannot take an argument.\n&quot;</span>, .{ </span>
+<span class="line" id="L90">                                        short_pf, </span>
+<span class="line" id="L91">                                        opt.short_name, </span>
+<span class="line" id="L92">                                        opt.name </span>
+<span class="line" id="L93">                                    });</span>
+<span class="line" id="L94">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
+<span class="line" id="L95">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L96">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.BoolCannotTakeArgument;</span>
+<span class="line" id="L97">                                }</span>
+<span class="line" id="L98">                                <span class="tok-kw">if</span> (short_idx + <span class="tok-number">2</span> &gt;= short_opts.len) <span class="tok-kw">return</span> <span class="tok-kw">error</span>.EmptyArgumentProvidedToOption;</span>
+<span class="line" id="L99">                                <span class="tok-kw">const</span> opt_arg = short_opts[(short_idx + <span class="tok-number">2</span>)..];</span>
+<span class="line" id="L100">                                opt.val.set(opt_arg) <span class="tok-kw">catch</span> {</span>
+<span class="line" id="L101">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{c}{?c}: {s}'.\n&quot;</span>, .{ </span>
+<span class="line" id="L102">                                        short_pf,</span>
+<span class="line" id="L103">                                        opt.short_name, </span>
+<span class="line" id="L104">                                        opt.name </span>
+<span class="line" id="L105">                                    });</span>
+<span class="line" id="L106">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
+<span class="line" id="L107">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L108">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
+<span class="line" id="L109">                                };</span>
+<span class="line" id="L110">                                log.debug(<span class="tok-str">&quot;Parsed Option '{?c}'.&quot;</span>, .{ opt.short_name });</span>
+<span class="line" id="L111">                                <span class="tok-kw">continue</span> :parseArg;</span>
+<span class="line" id="L112">                            }</span>
+<span class="line" id="L113">                            <span class="tok-comment">// Handle final Option in a chain of Short Options</span>
 </span>
-<span class="line" id="L66">                            <span class="tok-kw">try</span> <span class="tok-kw">if</span> (short_opts[short_idx + <span class="tok-number">1</span>] == <span class="tok-str">'='</span>) {</span>
-<span class="line" id="L67">                                <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) {</span>
-<span class="line" id="L68">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;The Option '{c}{?c}: {s}' is a Boolean/Toggle and cannot take an argument.\n&quot;</span>, .{ </span>
-<span class="line" id="L69">                                        short_pf, </span>
-<span class="line" id="L70">                                        opt.short_name, </span>
-<span class="line" id="L71">                                        opt.name </span>
-<span class="line" id="L72">                                    });</span>
-<span class="line" id="L73">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
-<span class="line" id="L74">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L75">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.BoolCannotTakeArgument;</span>
-<span class="line" id="L76">                                }</span>
-<span class="line" id="L77">                                <span class="tok-kw">if</span> (short_idx + <span class="tok-number">2</span> &gt;= short_opts.len) <span class="tok-kw">return</span> <span class="tok-kw">error</span>.EmptyArgumentProvidedToOption;</span>
-<span class="line" id="L78">                                <span class="tok-kw">const</span> opt_arg = short_opts[(short_idx + <span class="tok-number">2</span>)..];</span>
-<span class="line" id="L79">                                opt.val.set(opt_arg) <span class="tok-kw">catch</span> {</span>
-<span class="line" id="L80">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{c}{?c}: {s}'.\n&quot;</span>, .{ </span>
-<span class="line" id="L81">                                        short_pf,</span>
-<span class="line" id="L82">                                        opt.short_name, </span>
-<span class="line" id="L83">                                        opt.name </span>
-<span class="line" id="L84">                                    });</span>
-<span class="line" id="L85">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
-<span class="line" id="L86">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L87">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
-<span class="line" id="L88">                                };</span>
-<span class="line" id="L89">                                log.debug(<span class="tok-str">&quot;Parsed Option '{?c}'.&quot;</span>, .{ opt.short_name });</span>
-<span class="line" id="L90">                                <span class="tok-kw">continue</span> :parseArg;</span>
-<span class="line" id="L91">                            }</span>
-<span class="line" id="L92">                            <span class="tok-comment">// Handle final Option in a chain of Short Options</span>
+<span class="line" id="L114">                            <span class="tok-kw">else</span> <span class="tok-kw">if</span> (short_idx == short_opts.len - <span class="tok-number">1</span>) { </span>
+<span class="line" id="L115">                                <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) <span class="tok-kw">try</span> <span class="tok-builtin">@constCast</span>(opt).val.set(<span class="tok-str">&quot;true&quot;</span>)</span>
+<span class="line" id="L116">                                <span class="tok-kw">else</span> {</span>
+<span class="line" id="L117">                                    parseOpt(args, <span class="tok-builtin">@TypeOf</span>(opt.*), opt) <span class="tok-kw">catch</span> {</span>
+<span class="line" id="L118">                                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{c}{?c}: {s}'.\n&quot;</span>, .{ </span>
+<span class="line" id="L119">                                            short_pf,</span>
+<span class="line" id="L120">                                            opt.short_name, </span>
+<span class="line" id="L121">                                            opt.name </span>
+<span class="line" id="L122">                                        });</span>
+<span class="line" id="L123">                                        <span class="tok-kw">try</span> opt.usage(writer);</span>
+<span class="line" id="L124">                                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L125">                                        <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
+<span class="line" id="L126">                                    };</span>
+<span class="line" id="L127">                                }</span>
+<span class="line" id="L128">                                log.debug(<span class="tok-str">&quot;Parsed Option '{?c}'.&quot;</span>, .{ opt.short_name });</span>
+<span class="line" id="L129">                                <span class="tok-kw">continue</span> :parseArg;</span>
+<span class="line" id="L130">                            }</span>
+<span class="line" id="L131">                            <span class="tok-comment">// Handle a boolean Option before the final Short Option in a chain.</span>
 </span>
-<span class="line" id="L93">                            <span class="tok-kw">else</span> <span class="tok-kw">if</span> (short_idx == short_opts.len - <span class="tok-number">1</span>) { </span>
-<span class="line" id="L94">                                <span class="tok-kw">try</span> <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) <span class="tok-builtin">@constCast</span>(opt).val.set(<span class="tok-str">&quot;true&quot;</span>)</span>
-<span class="line" id="L95">                                <span class="tok-kw">else</span> {</span>
-<span class="line" id="L96">                                    parseOpt(args, <span class="tok-builtin">@TypeOf</span>(opt.*), opt) <span class="tok-kw">catch</span> {</span>
-<span class="line" id="L97">                                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{c}{?c}: {s}'.\n&quot;</span>, .{ </span>
-<span class="line" id="L98">                                            short_pf,</span>
-<span class="line" id="L99">                                            opt.short_name, </span>
-<span class="line" id="L100">                                            opt.name </span>
-<span class="line" id="L101">                                        });</span>
-<span class="line" id="L102">                                        <span class="tok-kw">try</span> opt.usage(writer);</span>
-<span class="line" id="L103">                                        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L104">                                        <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
-<span class="line" id="L105">                                    };</span>
-<span class="line" id="L106">                                };</span>
-<span class="line" id="L107">                                log.debug(<span class="tok-str">&quot;Parsed Option '{?c}'.&quot;</span>, .{ opt.short_name });</span>
-<span class="line" id="L108">                                <span class="tok-kw">continue</span> :parseArg;</span>
-<span class="line" id="L109">                            }</span>
-<span class="line" id="L110">                            <span class="tok-kw">else</span> <span class="tok-builtin">@constCast</span>(opt).val.set(<span class="tok-str">&quot;true&quot;</span>);</span>
-<span class="line" id="L111">                            log.debug(<span class="tok-str">&quot;Parsed Option '{?c}'.&quot;</span>, .{ opt.short_name });</span>
-<span class="line" id="L112">                            <span class="tok-kw">continue</span> :shortOpts;</span>
-<span class="line" id="L113">                        }</span>
-<span class="line" id="L114">                    }</span>
-<span class="line" id="L115">                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{c}{?c}'.\n&quot;</span>, .{ short_pf, short_opt });</span>
-<span class="line" id="L116">                    <span class="tok-kw">try</span> cmd.usage(writer);</span>
-<span class="line" id="L117">                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L118">                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
-<span class="line" id="L119">                }</span>
-<span class="line" id="L120">            }</span>
-<span class="line" id="L121">            <span class="tok-comment">// - Long Options</span>
+<span class="line" id="L132">                            <span class="tok-kw">else</span> <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) {</span>
+<span class="line" id="L133">                                <span class="tok-kw">try</span> <span class="tok-builtin">@constCast</span>(opt).val.set(<span class="tok-str">&quot;true&quot;</span>);</span>
+<span class="line" id="L134">                                log.debug(<span class="tok-str">&quot;Parsed Option '{?c}'.&quot;</span>, .{ opt.short_name });</span>
+<span class="line" id="L135">                                <span class="tok-kw">continue</span> :shortOpts;</span>
+<span class="line" id="L136">                            }</span>
+<span class="line" id="L137">                            <span class="tok-comment">// Handle a non-boolean Option which is given a Value without a space ' ' to separate them.</span>
 </span>
-<span class="line" id="L122">            <span class="tok-kw">else</span> <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, arg[<span class="tok-number">0</span>..<span class="tok-number">2</span>], long_pf)) {</span>
-<span class="line" id="L123">                <span class="tok-kw">const</span> long_opt = arg[<span class="tok-number">2</span>..];</span>
-<span class="line" id="L124">                <span class="tok-kw">for</span> (cmd.opts.?) |opt| {</span>
-<span class="line" id="L125">                    <span class="tok-kw">const</span> long_len = opt.long_name.?.len;</span>
-<span class="line" id="L126">                    <span class="tok-kw">if</span> (opt.long_name != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L127">                        <span class="tok-comment">// Handle Value provided to this Option with '=' instead of ' '.</span>
+<span class="line" id="L138">                            <span class="tok-kw">else</span> <span class="tok-kw">if</span> (parse_config.allow_opt_val_no_space) {</span>
+<span class="line" id="L139">                                <span class="tok-kw">var</span> short_names_buf: [<span class="tok-number">100</span>]<span class="tok-type">u8</span> = <span class="tok-null">undefined</span>;</span>
+<span class="line" id="L140">                                <span class="tok-kw">const</span> short_names = short_names_buf[<span class="tok-number">0</span>..];</span>
+<span class="line" id="L141">                                <span class="tok-kw">for</span> (cmd.opts.?, <span class="tok-number">0</span>..) |s_opt, idx| short_names[idx] = s_opt.short_name.?;</span>
+<span class="line" id="L142">                                <span class="tok-kw">if</span> (mem.indexOfScalar(<span class="tok-type">u8</span>, short_names, short_opts[short_idx + <span class="tok-number">1</span>]) == <span class="tok-null">null</span>) {</span>
+<span class="line" id="L143">                                    <span class="tok-kw">try</span> <span class="tok-builtin">@constCast</span>(opt).val.set(short_opts[(short_idx + <span class="tok-number">1</span>)..]);</span>
+<span class="line" id="L144">                                    log.debug(<span class="tok-str">&quot;Parsed Option '{?c}'.&quot;</span>, .{ opt.short_name });</span>
+<span class="line" id="L145">                                    <span class="tok-kw">continue</span> :parseArg;</span>
+<span class="line" id="L146">                                }</span>
+<span class="line" id="L147">                            }</span>
+<span class="line" id="L148">                        }</span>
+<span class="line" id="L149">                    }</span>
+<span class="line" id="L150">                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{c}{?c}'.\n&quot;</span>, .{ short_pf, short_opt });</span>
+<span class="line" id="L151">                    <span class="tok-kw">try</span> cmd.usage(writer);</span>
+<span class="line" id="L152">                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L153">                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
+<span class="line" id="L154">                }</span>
+<span class="line" id="L155">            }</span>
+<span class="line" id="L156">            <span class="tok-comment">// - Long Options</span>
 </span>
-<span class="line" id="L128">                        <span class="tok-kw">if</span> (long_opt.len &gt; opt.long_name.?.len <span class="tok-kw">and</span> eql(<span class="tok-type">u8</span>, long_opt[<span class="tok-number">0</span>..long_len], opt.long_name.?)) {</span>
-<span class="line" id="L129">                            <span class="tok-kw">if</span> (long_opt[long_len] == <span class="tok-str">'='</span>) {</span>
-<span class="line" id="L130">                                <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) {</span>
-<span class="line" id="L131">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;The Option '{s}{?s}: {s}' is a Boolean/Toggle and cannot take an argument.\n&quot;</span>, .{ </span>
-<span class="line" id="L132">                                        long_pf, </span>
-<span class="line" id="L133">                                        opt.long_name, </span>
-<span class="line" id="L134">                                        opt.name </span>
-<span class="line" id="L135">                                    });</span>
-<span class="line" id="L136">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
-<span class="line" id="L137">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L138">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.BoolCannotTakeArgument;</span>
-<span class="line" id="L139">                                }</span>
-<span class="line" id="L140">                                <span class="tok-kw">if</span> (long_len + <span class="tok-number">1</span> &gt;= long_opt.len) <span class="tok-kw">return</span> <span class="tok-kw">error</span>.EmptyArgumentProvidedToOption;</span>
-<span class="line" id="L141">                                <span class="tok-kw">const</span> opt_arg = long_opt[(long_len + <span class="tok-number">1</span>)..];</span>
-<span class="line" id="L142">                                opt.val.set(opt_arg) <span class="tok-kw">catch</span> {</span>
-<span class="line" id="L143">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{s}{?s}: {s}'.\n&quot;</span>, .{ </span>
-<span class="line" id="L144">                                        long_pf,</span>
-<span class="line" id="L145">                                        opt.long_name, </span>
-<span class="line" id="L146">                                        opt.name </span>
-<span class="line" id="L147">                                    });</span>
-<span class="line" id="L148">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
-<span class="line" id="L149">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L150">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
-<span class="line" id="L151">                                };</span>
-<span class="line" id="L152">                                log.debug(<span class="tok-str">&quot;Parsed Option '{?s}'.&quot;</span>, .{ opt.long_name });</span>
-<span class="line" id="L153">                                <span class="tok-kw">continue</span> :parseArg;</span>
-<span class="line" id="L154">                            }</span>
-<span class="line" id="L155">                        }</span>
-<span class="line" id="L156">                        <span class="tok-comment">// Handle normally provided Value to Option</span>
+<span class="line" id="L157">            <span class="tok-kw">else</span> <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, arg[<span class="tok-number">0</span>..<span class="tok-number">2</span>], long_pf)) {</span>
+<span class="line" id="L158">                <span class="tok-kw">const</span> long_opt = arg[<span class="tok-number">2</span>..];</span>
+<span class="line" id="L159">                <span class="tok-kw">for</span> (cmd.opts.?) |opt| {</span>
+<span class="line" id="L160">                    <span class="tok-kw">const</span> long_len = opt.long_name.?.len;</span>
+<span class="line" id="L161">                    <span class="tok-kw">if</span> (opt.long_name != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L162">                        <span class="tok-comment">// Handle Value provided to this Option with custom Separator (ex: '=') instead of a space ' '.</span>
 </span>
-<span class="line" id="L157">                        <span class="tok-kw">else</span> <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, long_opt, opt.long_name.?)) {</span>
-<span class="line" id="L158">                            <span class="tok-comment">// Handle Boolean/Toggle Option.</span>
+<span class="line" id="L163">                        <span class="tok-kw">if</span> (long_opt.len &gt; opt.long_name.?.len <span class="tok-kw">and</span> eql(<span class="tok-type">u8</span>, long_opt[<span class="tok-number">0</span>..long_len], opt.long_name.?)) {</span>
+<span class="line" id="L164">                            <span class="tok-kw">if</span> (mem.indexOfScalar(<span class="tok-type">u8</span>, parse_config.opt_val_seps, long_opt[long_len]) != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L165">                                <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) {</span>
+<span class="line" id="L166">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;The Option '{s}{?s}: {s}' is a Boolean/Toggle and cannot take an argument.\n&quot;</span>, .{ </span>
+<span class="line" id="L167">                                        long_pf, </span>
+<span class="line" id="L168">                                        opt.long_name, </span>
+<span class="line" id="L169">                                        opt.name </span>
+<span class="line" id="L170">                                    });</span>
+<span class="line" id="L171">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
+<span class="line" id="L172">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L173">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.BoolCannotTakeArgument;</span>
+<span class="line" id="L174">                                }</span>
+<span class="line" id="L175">                                <span class="tok-kw">if</span> (long_len + <span class="tok-number">1</span> &gt;= long_opt.len) <span class="tok-kw">return</span> <span class="tok-kw">error</span>.EmptyArgumentProvidedToOption;</span>
+<span class="line" id="L176">                                <span class="tok-kw">const</span> opt_arg = long_opt[(long_len + <span class="tok-number">1</span>)..];</span>
+<span class="line" id="L177">                                opt.val.set(opt_arg) <span class="tok-kw">catch</span> {</span>
+<span class="line" id="L178">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{s}{?s}: {s}'.\n&quot;</span>, .{ </span>
+<span class="line" id="L179">                                        long_pf,</span>
+<span class="line" id="L180">                                        opt.long_name, </span>
+<span class="line" id="L181">                                        opt.name </span>
+<span class="line" id="L182">                                    });</span>
+<span class="line" id="L183">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
+<span class="line" id="L184">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L185">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
+<span class="line" id="L186">                                };</span>
+<span class="line" id="L187">                                log.debug(<span class="tok-str">&quot;Parsed Option '{?s}'.&quot;</span>, .{ opt.long_name });</span>
+<span class="line" id="L188">                                <span class="tok-kw">continue</span> :parseArg;</span>
+<span class="line" id="L189">                            }</span>
+<span class="line" id="L190">                        }</span>
+<span class="line" id="L191">                        <span class="tok-comment">// Handle normally provided Value to Option</span>
 </span>
-<span class="line" id="L159">                            <span class="tok-kw">try</span> <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) <span class="tok-builtin">@constCast</span>(opt).val.set(<span class="tok-str">&quot;true&quot;</span>)</span>
-<span class="line" id="L160">                            <span class="tok-comment">// Handle Option with normal Argument.</span>
+<span class="line" id="L192">                        <span class="tok-kw">else</span> <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, long_opt, opt.long_name.?)) {</span>
+<span class="line" id="L193">                            <span class="tok-comment">// Handle Boolean/Toggle Option.</span>
 </span>
-<span class="line" id="L161">                            <span class="tok-kw">else</span> {</span>
-<span class="line" id="L162">                                parseOpt(args, <span class="tok-builtin">@TypeOf</span>(opt.*), opt) <span class="tok-kw">catch</span> {</span>
-<span class="line" id="L163">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{s}{?s}: {s}'.\n&quot;</span>, .{ </span>
-<span class="line" id="L164">                                        long_pf,</span>
-<span class="line" id="L165">                                        opt.long_name, </span>
-<span class="line" id="L166">                                        opt.name </span>
-<span class="line" id="L167">                                    });</span>
-<span class="line" id="L168">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
-<span class="line" id="L169">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L170">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
-<span class="line" id="L171">                                };</span>
-<span class="line" id="L172">                            };</span>
-<span class="line" id="L173">                            log.debug(<span class="tok-str">&quot;Parsed Option '{?s}'.&quot;</span>, .{ opt.long_name });</span>
-<span class="line" id="L174">                            <span class="tok-kw">continue</span> :parseArg;</span>
-<span class="line" id="L175">                        }</span>
-<span class="line" id="L176">                    }</span>
-<span class="line" id="L177">                }</span>
-<span class="line" id="L178">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Argument '{s}{?s}' to an Option.\n&quot;</span>, .{ long_pf, long_opt });</span>
-<span class="line" id="L179">                <span class="tok-kw">try</span> cmd.usage(writer);</span>
-<span class="line" id="L180">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
-<span class="line" id="L181">                <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
-<span class="line" id="L182">            }</span>
-<span class="line" id="L183">            unmatched = <span class="tok-null">true</span>;</span>
-<span class="line" id="L184">            log.debug(<span class="tok-str">&quot;No Options Matched for Command '{s}'.&quot;</span>, .{ cmd.name });</span>
-<span class="line" id="L185">        }</span>
-<span class="line" id="L186">        <span class="tok-comment">// ...Finally, for any Values.</span>
+<span class="line" id="L194">                            <span class="tok-kw">if</span> (eql(<span class="tok-type">u8</span>, opt.val.valType(), <span class="tok-str">&quot;bool&quot;</span>)) <span class="tok-kw">try</span> <span class="tok-builtin">@constCast</span>(opt).val.set(<span class="tok-str">&quot;true&quot;</span>)</span>
+<span class="line" id="L195">                            <span class="tok-comment">// Handle Option with normal Argument.</span>
 </span>
-<span class="line" id="L187">        <span class="tok-kw">if</span> (cmd.vals != <span class="tok-null">null</span>) {</span>
-<span class="line" id="L188">            log.debug(<span class="tok-str">&quot;Attempting to Parse Values...&quot;</span>, .{});</span>
-<span class="line" id="L189">            <span class="tok-kw">if</span> (val_idx &gt;= cmd.vals.?.len) {</span>
-<span class="line" id="L190">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Too many Values provided for Command '{s}'.\n&quot;</span>, .{ cmd.name });</span>
-<span class="line" id="L191">                <span class="tok-kw">try</span> cmd.usage(writer);</span>
-<span class="line" id="L192">                <span class="tok-kw">return</span> <span class="tok-kw">error</span>.TooManyValues;</span>
-<span class="line" id="L193">            }</span>
-<span class="line" id="L194">            <span class="tok-kw">const</span> val = cmd.vals.?[val_idx];</span>
-<span class="line" id="L195">            val.set(arg) <span class="tok-kw">catch</span> {</span>
-<span class="line" id="L196">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Argument '{s}' to Value '{s}'\n&quot;</span>, .{ arg, val.name() });</span>
-<span class="line" id="L197">                <span class="tok-kw">try</span> cmd.usage(writer);</span>
-<span class="line" id="L198">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n&quot;</span>, .{});</span>
-<span class="line" id="L199">            };</span>
-<span class="line" id="L200">            val_idx += <span class="tok-number">1</span>;</span>
-<span class="line" id="L201"></span>
-<span class="line" id="L202">            log.debug(<span class="tok-str">&quot;Parsed Value '{?s}'.&quot;</span>, .{ val.name() });</span>
-<span class="line" id="L203">            <span class="tok-kw">continue</span> :parseArg;</span>
-<span class="line" id="L204">        }</span>
-<span class="line" id="L205"></span>
-<span class="line" id="L206">        <span class="tok-comment">// Check if the Command expected an Argument but didn't get a match.</span>
+<span class="line" id="L196">                            <span class="tok-kw">else</span> {</span>
+<span class="line" id="L197">                                parseOpt(args, <span class="tok-builtin">@TypeOf</span>(opt.*), opt) <span class="tok-kw">catch</span> {</span>
+<span class="line" id="L198">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Option '{s}{?s}: {s}'.\n&quot;</span>, .{ </span>
+<span class="line" id="L199">                                        long_pf,</span>
+<span class="line" id="L200">                                        opt.long_name, </span>
+<span class="line" id="L201">                                        opt.name </span>
+<span class="line" id="L202">                                    });</span>
+<span class="line" id="L203">                                    <span class="tok-kw">try</span> opt.usage(writer);</span>
+<span class="line" id="L204">                                    <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L205">                                    <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
+<span class="line" id="L206">                                };</span>
+<span class="line" id="L207">                            }</span>
+<span class="line" id="L208">                            log.debug(<span class="tok-str">&quot;Parsed Option '{?s}'.&quot;</span>, .{ opt.long_name });</span>
+<span class="line" id="L209">                            <span class="tok-kw">continue</span> :parseArg;</span>
+<span class="line" id="L210">                        }</span>
+<span class="line" id="L211">                    }</span>
+<span class="line" id="L212">                }</span>
+<span class="line" id="L213">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Argument '{s}{?s}' to an Option.\n&quot;</span>, .{ long_pf, long_opt });</span>
+<span class="line" id="L214">                <span class="tok-kw">try</span> cmd.usage(writer);</span>
+<span class="line" id="L215">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n\n&quot;</span>, .{});</span>
+<span class="line" id="L216">                <span class="tok-kw">return</span> <span class="tok-kw">error</span>.CouldNotParseOption;</span>
+<span class="line" id="L217">            }</span>
+<span class="line" id="L218">            unmatched = <span class="tok-null">true</span>;</span>
+<span class="line" id="L219">            log.debug(<span class="tok-str">&quot;No Options Matched for Command '{s}'.&quot;</span>, .{ cmd.name });</span>
+<span class="line" id="L220">        }</span>
+<span class="line" id="L221">        <span class="tok-comment">// ...Finally, for any Values.</span>
 </span>
-<span class="line" id="L207">        <span class="tok-kw">if</span> (unmatched) {</span>
-<span class="line" id="L208">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Unrecognized Argument '{s}' for Command '{s}'.\n&quot;</span>, .{ arg, cmd.name });</span>
-<span class="line" id="L209">            <span class="tok-kw">try</span> cmd.help(writer);</span>
-<span class="line" id="L210">            <span class="tok-kw">return</span> <span class="tok-kw">error</span>.UnrecognizedArgument;</span>
-<span class="line" id="L211">        }</span>
-<span class="line" id="L212">        <span class="tok-comment">// For Commands that expect no arguments but are given one, fail to usage</span>
+<span class="line" id="L222">        <span class="tok-kw">if</span> (cmd.vals != <span class="tok-null">null</span>) {</span>
+<span class="line" id="L223">            log.debug(<span class="tok-str">&quot;Attempting to Parse Values...&quot;</span>, .{});</span>
+<span class="line" id="L224">            <span class="tok-kw">if</span> (val_idx &gt;= cmd.vals.?.len) {</span>
+<span class="line" id="L225">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Too many Values provided for Command '{s}'.\n&quot;</span>, .{ cmd.name });</span>
+<span class="line" id="L226">                <span class="tok-kw">try</span> cmd.usage(writer);</span>
+<span class="line" id="L227">                <span class="tok-kw">return</span> <span class="tok-kw">error</span>.TooManyValues;</span>
+<span class="line" id="L228">            }</span>
+<span class="line" id="L229">            <span class="tok-kw">const</span> val = cmd.vals.?[val_idx];</span>
+<span class="line" id="L230">            val.set(arg) <span class="tok-kw">catch</span> {</span>
+<span class="line" id="L231">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Could not parse Argument '{s}' to Value '{s}'.\n&quot;</span>, .{ arg, val.name() });</span>
+<span class="line" id="L232">                <span class="tok-kw">try</span> cmd.usage(writer);</span>
+<span class="line" id="L233">                <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;\n&quot;</span>, .{});</span>
+<span class="line" id="L234">            };</span>
+<span class="line" id="L235">            val_idx += <span class="tok-number">1</span>;</span>
+<span class="line" id="L236"></span>
+<span class="line" id="L237">            log.debug(<span class="tok-str">&quot;Parsed Value '{?s}'.&quot;</span>, .{ val.name() });</span>
+<span class="line" id="L238">            <span class="tok-kw">continue</span> :parseArg;</span>
+<span class="line" id="L239">        }</span>
+<span class="line" id="L240"></span>
+<span class="line" id="L241">        <span class="tok-comment">// Check if the Command expected an Argument but didn't get a match.</span>
 </span>
-<span class="line" id="L213">        <span class="tok-kw">else</span> {</span>
-<span class="line" id="L214">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Command '{s}' does not expect any arguments, but '{s}' was passed.\n&quot;</span>, .{ cmd.name, arg });</span>
-<span class="line" id="L215">            <span class="tok-kw">try</span> cmd.help(writer);</span>
-<span class="line" id="L216">            <span class="tok-kw">return</span> <span class="tok-kw">error</span>.UnexpectedArgument;</span>
-<span class="line" id="L217">        }</span>
-<span class="line" id="L218">    }</span>
-<span class="line" id="L219">}</span>
-<span class="line" id="L220"></span>
-<span class="line" id="L221"><span class="tok-comment">/// Parse an Option for the given Command.</span></span>
-<span class="line" id="L222"><span class="tok-kw">fn</span> <span class="tok-fn">parseOpt</span>(args: *<span class="tok-kw">const</span> proc.ArgIterator, <span class="tok-kw">comptime</span> opt_type: <span class="tok-type">type</span>, opt: *<span class="tok-kw">const</span> opt_type) !<span class="tok-type">void</span> {</span>
-<span class="line" id="L223">    <span class="tok-kw">const</span> peak_arg = argsPeak(args);</span>
-<span class="line" id="L224">    <span class="tok-kw">const</span> set_arg = </span>
-<span class="line" id="L225">        <span class="tok-kw">if</span> (peak_arg == <span class="tok-null">null</span> <span class="tok-kw">or</span> peak_arg.?[<span class="tok-number">0</span>] == <span class="tok-str">'-'</span>) setArg: {</span>
-<span class="line" id="L226">            _ = <span class="tok-builtin">@constCast</span>(args).next();</span>
-<span class="line" id="L227">            <span class="tok-kw">break</span> :setArg <span class="tok-str">&quot;true&quot;</span>;</span>
-<span class="line" id="L228">        }</span>
-<span class="line" id="L229">        <span class="tok-kw">else</span> <span class="tok-builtin">@constCast</span>(args).next().?;</span>
-<span class="line" id="L230">    <span class="tok-kw">try</span> opt.val.set(set_arg);</span>
-<span class="line" id="L231">}</span>
-<span class="line" id="L232"></span>
-<span class="line" id="L233"><span class="tok-comment">/// Peak at the next Argument in the provided ArgIterator without advancing the index.</span></span>
-<span class="line" id="L234"><span class="tok-kw">fn</span> <span class="tok-fn">argsPeak</span>(args: *<span class="tok-kw">const</span> proc.ArgIterator) ?[]<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
-<span class="line" id="L235">    <span class="tok-kw">const</span> peak_arg = <span class="tok-builtin">@constCast</span>(args).next();</span>
-<span class="line" id="L236">    <span class="tok-builtin">@constCast</span>(args).inner.index -= <span class="tok-number">1</span>;</span>
-<span class="line" id="L237">    <span class="tok-kw">return</span> peak_arg;</span>
-<span class="line" id="L238">}</span>
-<span class="line" id="L239"></span>
+<span class="line" id="L242">        <span class="tok-kw">if</span> (unmatched) {</span>
+<span class="line" id="L243">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Unrecognized Argument '{s}' for Command '{s}'.\n&quot;</span>, .{ arg, cmd.name });</span>
+<span class="line" id="L244">            <span class="tok-kw">try</span> cmd.help(writer);</span>
+<span class="line" id="L245">            <span class="tok-kw">return</span> <span class="tok-kw">error</span>.UnrecognizedArgument;</span>
+<span class="line" id="L246">        }</span>
+<span class="line" id="L247">        <span class="tok-comment">// For Commands that expect no Arguments but are given one, fail to usage.</span>
+</span>
+<span class="line" id="L248">        <span class="tok-kw">else</span> {</span>
+<span class="line" id="L249">            <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Command '{s}' does not expect any arguments, but '{s}' was passed.\n&quot;</span>, .{ cmd.name, arg });</span>
+<span class="line" id="L250">            <span class="tok-kw">try</span> cmd.help(writer);</span>
+<span class="line" id="L251">            <span class="tok-kw">return</span> <span class="tok-kw">error</span>.UnexpectedArgument;</span>
+<span class="line" id="L252">        }</span>
+<span class="line" id="L253">    }</span>
+<span class="line" id="L254">    <span class="tok-comment">// Check for missing Values if they are Mandated.</span>
+</span>
+<span class="line" id="L255">    <span class="tok-kw">if</span> (parse_config.vals_mandatory <span class="tok-kw">and</span> </span>
+<span class="line" id="L256">        cmd.vals != <span class="tok-null">null</span> <span class="tok-kw">and</span> </span>
+<span class="line" id="L257">        val_idx &lt; cmd.vals.?.len <span class="tok-kw">and</span> !</span>
+<span class="line" id="L258">        (cmd.checkFlag(<span class="tok-str">&quot;help&quot;</span>) <span class="tok-kw">or</span> cmd.checkFlag(<span class="tok-str">&quot;usage&quot;</span>))</span>
+<span class="line" id="L259">    ) {</span>
+<span class="line" id="L260">        <span class="tok-kw">try</span> writer.print(<span class="tok-str">&quot;Command '{s}' expects {d} Values, but only recieved {d}.\n&quot;</span>, .{</span>
+<span class="line" id="L261">            cmd.name,</span>
+<span class="line" id="L262">            cmd.vals.?.len,</span>
+<span class="line" id="L263">            val_idx,</span>
+<span class="line" id="L264">        });</span>
+<span class="line" id="L265">        <span class="tok-kw">try</span> cmd.help(writer);</span>
+<span class="line" id="L266">        <span class="tok-kw">return</span> <span class="tok-kw">error</span>.ExpectedMoreValues;</span>
+<span class="line" id="L267">    }</span>
+<span class="line" id="L268">}</span>
+<span class="line" id="L269"></span>
+<span class="line" id="L270"><span class="tok-comment">/// Parse an Option for the given Command.</span></span>
+<span class="line" id="L271"><span class="tok-kw">fn</span> <span class="tok-fn">parseOpt</span>(args: *<span class="tok-kw">const</span> proc.ArgIterator, <span class="tok-kw">comptime</span> opt_type: <span class="tok-type">type</span>, opt: *<span class="tok-kw">const</span> opt_type) !<span class="tok-type">void</span> {</span>
+<span class="line" id="L272">    <span class="tok-kw">const</span> peak_arg = argsPeak(args);</span>
+<span class="line" id="L273">    <span class="tok-kw">const</span> set_arg = </span>
+<span class="line" id="L274">        <span class="tok-kw">if</span> (peak_arg == <span class="tok-null">null</span> <span class="tok-kw">or</span> peak_arg.?[<span class="tok-number">0</span>] == <span class="tok-str">'-'</span>) setArg: {</span>
+<span class="line" id="L275">            _ = <span class="tok-builtin">@constCast</span>(args).next();</span>
+<span class="line" id="L276">            <span class="tok-kw">break</span> :setArg <span class="tok-str">&quot;true&quot;</span>;</span>
+<span class="line" id="L277">        }</span>
+<span class="line" id="L278">        <span class="tok-kw">else</span> <span class="tok-builtin">@constCast</span>(args).next().?;</span>
+<span class="line" id="L279">    <span class="tok-kw">try</span> opt.val.set(set_arg);</span>
+<span class="line" id="L280">}</span>
+<span class="line" id="L281"></span>
+<span class="line" id="L282"><span class="tok-comment">/// Peak at the next Argument in the provided ArgIterator without advancing the index.</span></span>
+<span class="line" id="L283"><span class="tok-kw">fn</span> <span class="tok-fn">argsPeak</span>(args: *<span class="tok-kw">const</span> proc.ArgIterator) ?[]<span class="tok-kw">const</span> <span class="tok-type">u8</span> {</span>
+<span class="line" id="L284">    <span class="tok-kw">const</span> peak_arg = <span class="tok-builtin">@constCast</span>(args).next();</span>
+<span class="line" id="L285">    <span class="tok-builtin">@constCast</span>(args).inner.index -= <span class="tok-number">1</span>;</span>
+<span class="line" id="L286">    <span class="tok-kw">return</span> peak_arg;</span>
+<span class="line" id="L287">}</span>
+<span class="line" id="L288"></span>
 </code></pre></body>
 </html>

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -19,7 +19,7 @@ const mem = std.mem;
 const StringHashMap = std.StringHashMap;
 
 const Option = @import("Option.zig");
-const Val = @import("Value.zig");
+const Value = @import("Value.zig");
 
 
 /// Config for custom Command types. 
@@ -76,7 +76,7 @@ pub fn Custom(comptime config: Config) type {
         /// The list of Options this Command can take.
         opts: ?[]*const CustomOption = null,
         /// The list of Values this Command can take.
-        vals: ?[]*const Val.Generic = null,
+        vals: ?[]*const Value.Generic = null,
 
         /// The Name of this Command for user identification and Usage/Help messages.
         name: []const u8,
@@ -99,9 +99,9 @@ pub fn Custom(comptime config: Config) type {
         }
 
         /// Gets a StringHashMap of this Command's Values.
-        pub fn getVals(self: *const @This(), alloc: mem.Allocator) !StringHashMap(*const Val) {
+        pub fn getVals(self: *const @This(), alloc: mem.Allocator) !StringHashMap(*const Value) {
             if (self.vals == null) return error.NoValuesInCommand;
-            var map = StringHashMap(*const Val).init(alloc);
+            var map = StringHashMap(*const Value).init(alloc);
             for (self.vals.?) |val| { try map.put(val.name, val); }
             return map;
         }
@@ -315,14 +315,14 @@ pub fn Custom(comptime config: Config) type {
                             .short_name = 'u',
                             .long_name = "usage",
                             .description = usage_description,
-                            .val = &Val.init(bool, .{ .name = "usageFlag" }),
+                            .val = &Value.ofType(bool, .{ .name = "usageFlag" }),
                         },
                         &@This().CustomOption{
                             .name = "help",
                             .short_name = 'h',
                             .long_name = "help",
                             .description = help_description, 
-                            .val = &Val.init(bool, .{ .name = "helpFlag" }),
+                            .val = &Value.ofType(bool, .{ .name = "helpFlag" }),
                         },
                     };
                     self.opts = 
@@ -391,8 +391,8 @@ pub fn Custom(comptime config: Config) type {
                     .long_name = "usage",
                     .description = usage_description,
                     .val = usageVal: {
-                        var usage_val = try alloc.create(Val.Generic);
-                        usage_val.* = Val.init(bool, .{ .name = "usageFlag" });
+                        var usage_val = try alloc.create(Value.Generic);
+                        usage_val.* = Value.ofType(bool, .{ .name = "usageFlag" });
                         break :usageVal usage_val;
                     },
                 };
@@ -403,8 +403,8 @@ pub fn Custom(comptime config: Config) type {
                     .long_name = "help",
                     .description = help_description,
                     .val = helpVal: {
-                        var help_val = try alloc.create(Val.Generic);
-                        help_val.* = Val.init(bool, .{ .name = "helpFlag" });
+                        var help_val = try alloc.create(Value.Generic);
+                        help_val.* = Value.ofType(bool, .{ .name = "helpFlag" });
                         break :helpVal help_val;
                     },
                 };

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -179,7 +179,37 @@ pub fn Custom(comptime config: Config) type {
             try writer.print("\n\n", .{});
         }
 
-        /// Find the Index of a Slice (Why is this not in std.mem?!?!?)
+        /// Check if a Flag has been set on this Command as a Command, an Option, or a Value.
+        /// This is particularly useful for checking if Help or Usage has been called.
+        pub fn checkFlag(self: *const @This(), toggle_name: []const u8) bool {
+            return (
+                (self.sub_cmd != null and mem.eql(u8, self.sub_cmd.?.name, toggle_name)) or
+                checkOpt: {
+                    if (self.opts != null) {
+                        for (self.opts.?) |opt| {
+                            if (mem.eql(u8, opt.name, toggle_name) and 
+                                mem.eql(u8, opt.val.valType(), "bool") and 
+                                opt.val.bool.get() catch false)
+                                    break :checkOpt true;
+                        }
+                    }
+                    break :checkOpt false;
+                } or
+                checkVal: {
+                    if (self.vals != null) {
+                        for (self.vals.?) |val| {
+                            if (mem.eql(u8, val.name(), toggle_name) and
+                                mem.eql(u8, val.valType(), "bool") and
+                                val.bool.get() catch false)
+                                    break :checkVal true;
+                        }
+                    }
+                    break :checkVal false;
+                }
+            );
+        }
+
+        /// Find the Index of a Slice (Why is this not in std.mem?!?!? Did I miss it?)
         fn indexOfEql(comptime T: type, haystack: []const T, needle: T) ?usize {
             switch (@typeInfo(T)) {
                 .Pointer => |ptr| {

--- a/src/Command.zig
+++ b/src/Command.zig
@@ -113,15 +113,15 @@ pub fn Custom(comptime config: Config) type {
             try self.usage(writer);
 
             try writer.print(\\HELP:
-                             \\    Command: {s}
+                             \\    COMMAND: {s}
                              \\
-                             \\    Description: {s}
+                             \\    DESCRIPTION: {s}
                              \\
                              \\
                              , .{ self.name, self.description });
             
             if (self.sub_cmds != null) {
-                try writer.print("    Sub Commands:\n", .{});
+                try writer.print("    SUB COMMANDS:\n", .{});
                 for (self.sub_cmds.?) |cmd| {
                     try writer.print("        ", .{});
                     try writer.print(subcmds_help_fmt, .{cmd.name, cmd.description});
@@ -131,7 +131,7 @@ pub fn Custom(comptime config: Config) type {
             try writer.print("\n", .{});
 
             if (self.opts != null) {
-                try writer.print("    Options:\n", .{});
+                try writer.print("    OPTIONS:\n", .{});
                 for (self.opts.?) |opt| {
                     try writer.print("        ", .{});
                     try opt.help(writer);
@@ -141,7 +141,7 @@ pub fn Custom(comptime config: Config) type {
             try writer.print("\n", .{});
 
             if (self.vals != null) {
-                try writer.print("    Values:\n", .{});
+                try writer.print("    VALUES:\n", .{});
                 for (self.vals.?) |val| {
                     try writer.print("        ", .{});
                     try writer.print(vals_help_fmt, .{ val.name(), val.valType(), val.description() });
@@ -225,10 +225,12 @@ pub fn Custom(comptime config: Config) type {
         pub fn validate(comptime self: *const @This()) void {
             comptime {
                 @setEvalBranchQuota(100_000);
+                // This is an arbitrary (but hopefully higher than needed) limit to the number of Arguments than be Validated each of Commands, Options, and Values.
+                const max_args = 100;
                 // Check for distinct Sub Commands and Validate them.
                 if (self.sub_cmds != null) {
                     const cmds = self.sub_cmds.?;
-                    var distinct_cmd: [100][]const u8 = .{ "" } ** 100;
+                    var distinct_cmd: [max_args][]const u8 = .{ "" } ** max_args;
                     for (cmds, 0..) |cmd, idx| {
                         if (indexOfEql([]const u8, distinct_cmd[0..idx], cmd.name) != null) 
                             @compileError("The Sub Command '" ++ cmd.name ++ "' is set more than once.");
@@ -240,9 +242,9 @@ pub fn Custom(comptime config: Config) type {
                 // Check for distinct Options.
                 if (self.opts != null) {
                     const opts = self.opts.?;
-                    var distinct_name: [100][]const u8 = .{ "" } ** 100;
-                    var distinct_short: [100]u8 = .{ ' ' } ** 100;
-                    var distinct_long: [100][]const u8 = .{ "" } ** 100;
+                    var distinct_name: [max_args][]const u8 = .{ "" } ** max_args;
+                    var distinct_short: [max_args]u8 = .{ ' ' } ** max_args;
+                    var distinct_long: [max_args][]const u8 = .{ "" } ** max_args;
                     for (opts, 0..) |opt, idx| {
                         if (indexOfEql([]const u8, distinct_name[0..], opt.name) != null) 
                             @compileError("The Option '" ++ opt.name ++ "' is set more than once.");
@@ -259,7 +261,7 @@ pub fn Custom(comptime config: Config) type {
                 // Check for distinct Values.
                 if (self.vals != null) {
                     const vals = self.vals.?;
-                    var distinct_val: [100][]const u8 = .{ "" } ** 100;
+                    var distinct_val: [max_args][]const u8 = .{ "" } ** max_args;
                     for (vals, 0..) |val, idx| {
                         if (indexOfEql([]const u8, distinct_val[0..], val.name()) != null) 
                             @compileError("The Value '" ++ val.name ++ "' is set more than once.");

--- a/src/Option.zig
+++ b/src/Option.zig
@@ -14,7 +14,7 @@ const ascii = std.ascii;
 
 const toUpper = ascii.toUpper;
 
-const Val = @import("Value.zig");
+const Value = @import("Value.zig");
     
 /// Config for custom Option types.
 pub const Config = struct {
@@ -49,7 +49,7 @@ pub fn Custom(comptime config: Config) type {
         /// This Option's Long Name (ex: `--intOpt`).
         long_name: ?[]const u8,
         /// This Option's wrapped Value.
-        val: *const Val.Generic = &Val.init(bool, .{}),
+        val: *const Value.Generic = &Value.ofType(bool, .{}),
 
         /// The Name of this Option for user identification and Usage/Help messages.
         /// Limited to 100B.

--- a/src/Option.zig
+++ b/src/Option.zig
@@ -12,7 +12,7 @@
 const std = @import("std");
 const ascii = std.ascii;
 
-const toUpper = ascii.upperString;
+const toUpper = ascii.toUpper;
 
 const Val = @import("Value.zig");
     
@@ -52,6 +52,7 @@ pub fn Custom(comptime config: Config) type {
         val: *const Val.Generic = &Val.init(bool, .{}),
 
         /// The Name of this Option for user identification and Usage/Help messages.
+        /// Limited to 100B.
         name: []const u8,
         /// The Description of this Option for Usage/Help messages.
         description: []const u8 = "",
@@ -73,7 +74,9 @@ pub fn Custom(comptime config: Config) type {
         /// Creates the Help message for this Option and Writes it to the provided Writer.
         pub fn help(self: *const @This(), writer: anytype) !void {
             var upper_name_buf: [100]u8 = undefined;
-            var upper_name = toUpper(upper_name_buf[0..], self.name);
+            const upper_name = upper_name_buf[0..];
+            upper_name[0] = toUpper(self.name[0]);
+            for(upper_name[1..self.name.len], 1..) |*c, i| c.* = self.name[i];
             if (help_fmt == null) {
                 try writer.print("{s}:\n            ", .{ upper_name });
                 try self.usage(writer);

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -36,7 +36,7 @@ pub fn Typed(comptime set_type: type) type {
         default_val: ?val_type = null,
         /// Flag to determine if this Value has been Parsed and Validated.
         is_set: bool = false,
-        /// A Validation Function to be used in set() following normal Parsing.
+        /// A Validation Function to be used in `set()` following normal Parsing.
         val_fn: ?*const fn(val_type) bool = struct{ fn valFn(val: val_type) bool { return @TypeOf(val) == val_type; } }.valFn,
             
         /// The Name of this Value for user identification and Usage/Help messages.
@@ -127,19 +127,19 @@ pub const Generic = genUnion: {
             }
         }
 
-        /// Get the inner Typed Value's name.
+        /// Get the inner Typed Value's Name.
         pub fn name(self: *const @This()) []const u8 {
             return switch (meta.activeTag(self.*)) {
                 inline else => |tag| @field(self, @tagName(tag)).name,
             };
         }
-        /// Get the inner Typed Value's type.
+        /// Get the inner Typed Value's Type.
         pub fn valType(self: *const @This()) []const u8 {
             return switch (meta.activeTag(self.*)) {
                 inline else => |tag| @typeName(@TypeOf(@field(self, @tagName(tag))).getType()),
             };
         }
-        /// Get the inner Typed Value's description.
+        /// Get the inner Typed Value's Description.
         pub fn description(self: *const @This()) []const u8 {
             return switch (meta.activeTag(self.*)) {
                 inline else => |tag| @field(self, @tagName(tag)).description,

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -23,6 +23,16 @@ const parseFloat = fmt.parseFloat;
 const Type = builtin.Type;
 const UnionField = Type.UnionField;
 
+/// The Behavior for Setting Values.
+/// These are currently only implemented for Values that are within Options.
+pub const SetBehavior = enum {
+    /// Keeps the First Argument this Value was Set to.
+    First,
+    /// Keeps the Last Argument this Value was Set to.
+    Last,
+    /// Keeps Multiple Arguments in this Value up to the set Max.
+    Multi,
+};
 
 /// Create a Value with a specific Type.
 pub fn Typed(comptime set_type: type) type {
@@ -30,8 +40,17 @@ pub fn Typed(comptime set_type: type) type {
         /// The inner Type of this Value.
         pub const val_type = set_type;
 
-        /// The Raw Argument provided to this Value for Parsing and Validation.
-        raw_arg: []const u8 = "",
+        /// The Parsed and Validated Argument(s) this Value has been set to.
+        /// Internal Use.
+        _set_args: [100]?val_type = .{ null } ** 100,
+        /// The current Index of Raw Arguments for this Value.
+        /// Internal Use.
+        _arg_idx: u7 = 0,
+        /// The Max number of Raw Arguments that can be provided.
+        /// This must be between 1 - 100.
+        max_args: u7 = 1,
+        /// Set Behavior for this Value.
+        set_behavior: SetBehavior = .Last,
         /// An optional Default Value.
         default_val: ?val_type = null,
         /// Flag to determine if this Value has been Parsed and Validated.
@@ -61,23 +80,44 @@ pub fn Typed(comptime set_type: type) type {
 
         /// Set this Value if the Argument can be Parsed and Validated.
         /// Blank ("") Arguments will be treated as the current Raw Argument of the Value.
-        pub fn set(self: *const @This(), arg: []const u8) !void {
-            const set_arg = if(eql(u8, arg, "")) self.raw_arg else arg;
-            const parsed_val = try self.parse(set_arg);
+        pub fn set(self: *const @This(), set_arg: []const u8) !void {
+            const parsed_arg = try self.parse(set_arg);
             @constCast(self).is_set =
-                if (self.val_fn != null) self.val_fn.?(parsed_val)
+                if (self.val_fn != null) self.val_fn.?(parsed_arg)
                 else true;
-            if (self.is_set) @constCast(self).raw_arg = set_arg
+            if (self.is_set) {
+                switch (self.set_behavior) {
+                    .First => if (self._set_args[0] == null) { 
+                        @constCast(self)._set_args[0] = parsed_arg;
+                    },
+                    .Last => @constCast(self)._set_args[0] = parsed_arg,
+                    .Multi => if (self._arg_idx < self.max_args) {
+                        @constCast(self)._set_args[self._arg_idx] = parsed_arg;
+                        @constCast(self)._arg_idx += 1;
+                    }
+                }
+            }
             else return error.InvalidValue;
         }
 
-        /// Get the Parsed and Validated Value.
+        /// Get the first Parsed and Validated Argument of this Value.
+        /// This will pull the first value from `_set_args` and should be used with the `First` or `Last` Set Behaviors.
         pub fn get(self: *const @This()) !val_type {
             return 
-                if (self.is_set) try self.parse(self.raw_arg)
+                if (self.is_set) self._set_args[0].?
                 else if (val_type == bool) false
                 else if (self.default_val != null) self.default_val.?
                 else error.ValueNotSet;
+        }
+
+        /// Get All Parsed and Validated Arguments of this Value.
+        /// This will pull All values from `_set_args` and should be used with `Multi` Set Behavior.
+        /// TODO: Make this more efficient.
+        pub fn getAll(self: *const @This(), alloc: mem.Allocator) ![]val_type {
+            if (!self.is_set) return error.ValueNotSet;
+            var vals = try alloc.alloc(val_type, self._arg_idx);
+            for (self._set_args[0..self._arg_idx], 0..) |arg, idx| vals[idx] = arg.?;
+            return vals;
         }
 
         /// Get the Value Type
@@ -145,6 +185,12 @@ pub const Generic = genUnion: {
                 inline else => |tag| @field(self, @tagName(tag)).description,
             };
         }
+        /// Check the inner Typed Value's is Set.
+        pub fn isSet(self: *const @This()) bool {
+            return switch (meta.activeTag(self.*)) {
+                inline else => |tag| @field(self, @tagName(tag)).is_set,
+            };
+        }
     };
 
     // TODO: See if there's another way to add these fields procedurally to avoid the declaration reification issue with @Type(builtin.Type{})
@@ -166,10 +212,8 @@ pub const Generic = genUnion: {
     break :genUnion gen_union;
 };
 
-/// Initialize a Generic Value with a specific Type.
-/// TODO: Coerce Typed([]u8) to Typed([]const u8) 
-pub fn init(comptime T: type, comptime typed_val: Typed(T)) Generic {
-    const active_tag = if (T == []const u8 or T == []u8) "string" else @typeName(T);
+/// Create a Generic Value with a specific Type.
+pub fn ofType(comptime T: type, comptime typed_val: Typed(T)) Generic {
+    const active_tag = if (T == []const u8) "string" else @typeName(T);
     return @unionInit(Generic, active_tag, typed_val);
 }
-


### PR DESCRIPTION
  - Added Customization to Mandate Values be filled.
  - Added Custom Prefixes for Options.
  - Added Custom Separator between Options and Values.
  - Added Custom Behavior for having the same option given multiple times. (First, Last, or Multi)
  - Added Customization to skip the first Argument (the executable's name).