### PR TITLE
Typo in example code + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+zig-out/
+zig-cache/
+bin/

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can call various methods on the Command to use that data however you need.
 ```zig
 // ...continued from the Comptime Setup.
 pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator;
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const alloc = arena.allocator();
 


### PR DESCRIPTION
Feel free to let me know you don't want a git ignore for some reason. I just found it strange when opening up the repo locally and working my way through the readme. 

The change to the README was just a parenthesis that was missing. 

I also get this from zls: `use of undeclared identifier 'builtin'` from here: https://github.com/00JCIV00/cova/blob/b9f127acfbb689a7f0dd7f1073ad463f55a29afe/README.md?plain=1#L142

I haven't dug into what's going on with this yet as I'm still working on implementing the example code, just wanted to push this to get it to your attention in the mean time. 

Thanks for the library! I'm excited to give it a try, it's design seems rather thought out from the beginning :)