### PR TITLE
fix: don't forget to flush (TM) when writing user messages

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -865,6 +865,8 @@ pub fn Custom(comptime config: Config) type {
                     },
                 }
             }
+
+            try writer.flush();
         }
 
         /// Creates the Usage message for this Command and writes it to the provided Writer (`writer`).
@@ -906,6 +908,7 @@ pub fn Custom(comptime config: Config) type {
             } 
 
             try writer.print("\n\n", .{});
+            try writer.flush();
         }
 
         /// Check if Usage or Help have been set and call their respective methods.


### PR DESCRIPTION
After the Writergate update, cova may no longer actually print the usage or help messages to buffered writers if they aren't flushed by the user, this PR fixes this by adding a fixed flush point after writing those messages.